### PR TITLE
Rename Toolbar to NavBar (#10)

### DIFF
--- a/greenlight/lib/__init__.py
+++ b/greenlight/lib/__init__.py
@@ -35,8 +35,8 @@ class Puppeteer(object):
     def tabstrip(self):
         pass
 
-    @use_lib_as_property('toolbar.Toolbar')
-    def toolbar(self):
+    @use_lib_as_property('navbar.NavBar')
+    def navbar(self):
         pass
 
     # these libs wrap gecko APIs

--- a/greenlight/lib/navbar.py
+++ b/greenlight/lib/navbar.py
@@ -2,7 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-class Toolbar(object):
+
+class NavBar(object):
     def __init__(self, client):
         self.client = client
 

--- a/greenlight/tests/functional/tabs/test_new_tab.py
+++ b/greenlight/tests/functional/tabs/test_new_tab.py
@@ -5,6 +5,7 @@
 from greenlight.harness.testcase import FirefoxTestCase
 from greenlight.harness.decorators import uses_lib
 
+
 class TestNewTab(FirefoxTestCase):
     def setUp(self):
         FirefoxTestCase.setUp(self)
@@ -18,7 +19,7 @@ class TestNewTab(FirefoxTestCase):
         # bug 1088223: active_tab not working
         FirefoxTestCase.tearDown(self)
 
-    @uses_lib('tabstrip', 'toolbar', 'prefs')
+    @uses_lib('tabstrip', 'navbar', 'prefs')
     def test_open_tab_by_newtab_button(self):
         self.marionette.set_context('chrome')
 
@@ -27,5 +28,4 @@ class TestNewTab(FirefoxTestCase):
         self.assertEqual(len(self.tabstrip.tabs), num_tabs + 1)
 
         newtab_url = self.prefs.get_pref('browser.newtab.url')
-        self.assertEqual(self.toolbar.location, newtab_url)
-
+        self.assertEqual(self.navbar.location, newtab_url)

--- a/greenlight/tests/functional/toolbar/test_back_forward.py
+++ b/greenlight/tests/functional/toolbar/test_back_forward.py
@@ -9,6 +9,7 @@ from marionette.errors import TimeoutException
 from greenlight.harness.testcase import FirefoxTestCase
 from greenlight.harness.decorators import uses_lib
 
+
 class TestBackForward(FirefoxTestCase):
 
     def setUp(self):
@@ -26,10 +27,10 @@ class TestBackForward(FirefoxTestCase):
                 self.marionette.navigate(url)
             self.assertEquals(self.marionette.get_url(), self.test_urls[-1])
 
-    @uses_lib('toolbar')
+    @uses_lib('navbar')
     def test_back_forward(self):
-        back = self.toolbar.back_button
-        forward = self.toolbar.forward_button
+        back = self.navbar.back_button
+        forward = self.navbar.forward_button
         self.assertFalse(forward.is_displayed())
 
         for i in range(1, len(self.test_urls)):
@@ -39,10 +40,11 @@ class TestBackForward(FirefoxTestCase):
             time.sleep(1)
 
             with self.marionette.using_context('content'):
-                self.assertEquals(self.marionette.get_url(), self.test_urls[-(i+1)])
+                self.assertEquals(self.marionette.get_url(),
+                                  self.test_urls[-(i + 1)])
 
         self.assertFalse(back.is_enabled())
-        forward = self.toolbar.forward_button
+        forward = self.navbar.forward_button
         # TODO For some reason this returns False
         #self.assertTrue(forward.is_displayed())
         self.assertTrue(forward.is_enabled())

--- a/greenlight/tests/functional/toolbar/test_home_button.py
+++ b/greenlight/tests/functional/toolbar/test_home_button.py
@@ -9,6 +9,7 @@ from greenlight.harness.decorators import uses_lib
 
 homepage_pref = 'browser.startup.homepage'
 
+
 class TestHomeButton(FirefoxTestCase):
 
     def setUp(self):
@@ -20,9 +21,9 @@ class TestHomeButton(FirefoxTestCase):
         self.lib.prefs.restore_pref(homepage_pref)
         FirefoxTestCase.tearDown(self)
 
-    @uses_lib('toolbar')
+    @uses_lib('navbar')
     def test_home_button(self):
-        self.toolbar.home_button.click()
+        self.navbar.home_button.click()
 
         # TODO wait_for_page_load
         time.sleep(1)


### PR DESCRIPTION
For consistency we have to use NavBar and not Toolbar for the navigation toolbar. Keep in mind that there will also be other toolbars like bookmarks, menu, tabs, and for add-ons via jetpack.
