### PR TITLE
Fix keys library and update expectation for test_browser_window based on fix.

### DIFF
--- a/greenlight/lib/api/keys.py
+++ b/greenlight/lib/api/keys.py
@@ -8,8 +8,11 @@ class Keys(marionette.keys.Keys):
     """Proxy to marionette's keys with an "accel" provided for convenience
     testing across platforms."""
 
-    def __init__(self, client):
-        if client.session_capabilities['platformName'] == 'DARWIN':
-            self.ACCEL = self.META
-        else:
-            self.ACCEL = self.CONTROL
+    def __init__(self, client_getter):
+        self.client_getter = client_getter
+
+    @property
+    def ACCEL(self):
+        if self.client_getter().session_capabilities['platformName'] == 'DARWIN':
+            return self.META
+        return self.CONTROL

--- a/greenlight/tests/functional/shortcuts/manifest.ini
+++ b/greenlight/tests/functional/shortcuts/manifest.ini
@@ -1,3 +1,1 @@
 [test_browser_window.py]
-# see test for specific todos
-fail-if = true


### PR DESCRIPTION
This test passes without e10s turned on.
