### PR TITLE
Move lib/ui/browser.py to lib/windows.py due to general window handling methods (#18)

### DIFF
--- a/greenlight/lib/__init__.py
+++ b/greenlight/lib/__init__.py
@@ -18,12 +18,12 @@ class Puppeteer(object):
 
     # these libs are for UI manipulation
 
-    @use_lib_as_property('ui.browser.Browser')
-    def browser(self):
+    @use_lib_as_property('windows.Windows')
+    def windows(self):
         """
-        Provides shortcuts to the top-level browser windows.
+        Provides shortcuts to the top-level windows.
 
-        See the :class:`~ui.browser.Browser` reference.
+        See the :class:`~window.Windows` reference.
         """
 
     @use_lib_as_property('ui.menu.MenuBar')

--- a/greenlight/lib/tests/manifest.ini
+++ b/greenlight/lib/tests/manifest.ini
@@ -1,4 +1,4 @@
-[test_browser.py]
 [test_l10n.py]
 [test_menubar.py]
 [test_tabs.py]
+[test_windows.py]

--- a/greenlight/lib/tests/test_windows.py
+++ b/greenlight/lib/tests/test_windows.py
@@ -4,68 +4,72 @@
 
 from marionette.errors import NoSuchElementException
 
-from greenlight.harness.decorators import uses_lib
 from greenlight.harness.testcase import FirefoxTestCase
 
 
-class TestBrowser(FirefoxTestCase):
+class TestWindows(FirefoxTestCase):
 
     def test_window_element(self):
-        first_window = self.browser.current_window
+        first_window = self.windows.current
         self.assertEquals(first_window.tag_name, 'window')
         self.assertEquals(first_window.get_attribute('id'), 'main-window')
 
-        self.assertEquals(len(self.browser.windows), 1)
+        self.assertEquals(len(self.windows.all), 1)
         self.assertEquals(len(self.marionette.window_handles), 1)
         first_window.send_shortcut('ctrl-n')
 
-        self.assertEquals(len(self.browser.windows), 2)
+        self.assertEquals(len(self.windows.all), 2)
         self.assertEquals(len(self.marionette.window_handles), 2)
         for handle in self.marionette.window_handles:
             if handle != first_window.handle:
                 self.marionette.switch_to_window(handle)
                 break
 
-        second_window = self.browser.current_window
+        second_window = self.windows.current
         self.assertNotEquals(first_window.handle, second_window.handle)
 
         first_window.switch_to()
-        self.assertEquals(first_window.handle, self.marionette.current_window_handle)
+        self.assertEquals(first_window.handle,
+                          self.marionette.current_window_handle)
         second_window.close()
-        self.assertEquals(first_window.handle, self.marionette.current_window_handle)
+        self.assertEquals(first_window.handle,
+                          self.marionette.current_window_handle)
         self.assertEquals(len(self.marionette.window_handles), 1)
 
     def test_switch_to_window(self):
         url = self.marionette.absolute_url('layout/mozilla')
 
-        first_window = self.browser.current_window
+        first_window = self.windows.current
         first_window.send_shortcut('ctrl-n')
         first_window.send_shortcut('ctrl-n')
 
-        windows = self.browser.windows
+        windows = self.windows.all
         self.assertEquals(len(windows), 3)
 
         with self.marionette.using_context('content'):
             self.marionette.navigate(url)
 
-        self.browser.switch_to_window(windows[1])
-        self.assertEquals(windows[1].handle, self.marionette.current_window_handle)
+        self.windows.switch_to(windows[1])
+        self.assertEquals(windows[1].handle,
+                          self.marionette.current_window_handle)
 
-        self.browser.switch_to_window(windows[2].handle)
-        self.assertEquals(windows[2].handle, self.marionette.current_window_handle)
+        self.windows.switch_to(windows[2].handle)
+        self.assertEquals(windows[2].handle,
+                          self.marionette.current_window_handle)
 
         def is_my_window():
             with self.marionette.using_context('content'):
                 return self.marionette.get_url() == url
 
-        self.browser.switch_to_window(is_my_window)
-        self.assertEquals(windows[0].handle, self.marionette.current_window_handle)
+        self.windows.switch_to(is_my_window)
+        self.assertEquals(windows[0].handle,
+                          self.marionette.current_window_handle)
 
         with self.assertRaises(NoSuchElementException):
-            self.browser.switch_to_window("humbug")
+            self.windows.switch_to("humbug")
 
         with self.assertRaises(NoSuchElementException):
-            self.browser.switch_to_window(lambda: False)
+            self.windows.switch_to(lambda: False)
 
         windows[1].close()
         windows[2].close()

--- a/greenlight/lib/windows.py
+++ b/greenlight/lib/windows.py
@@ -5,14 +5,14 @@
 from marionette.errors import NoSuchElementException
 from marionette.keys import Keys
 
-from ..base import BaseLib
-from .. import DOMElement
+from base import BaseLib
+from . import DOMElement
 
 
-class Browser(BaseLib):
+class Windows(BaseLib):
 
     @property
-    def windows(self):
+    def all(self):
         """
         :returns: a list of :class:`WindowElement`'s corresponding to the
                   windows in `marionette.window_handles`.
@@ -21,19 +21,19 @@ class Browser(BaseLib):
         windows = []
         for handle in self.client.window_handles:
             self.client.switch_to_window(handle)
-            windows.append(self.current_window)
+            windows.append(self.current)
         self.client.switch_to_window(old_handle)
         return windows
 
     @property
-    def current_window(self):
+    def current(self):
         """
         :returns: The :class:`WindowElement` for the currently active browser
                   window.
         """
         return self.WindowElement.create(self.client.find_element('id', 'main-window'))
 
-    def switch_to_window(self, target):
+    def switch_to(self, target):
         """
         Switches context to the specified window.
 
@@ -47,16 +47,15 @@ class Browser(BaseLib):
         isn't known. For example, say we want to switch to a window that has
         three tabs::
 
-            @uses_lib('browser', 'tabstrip')
             def test_switch_to_window_with_three_tabs(self):
                 def has_three_tabs():
                     return len(self.tabstrip.tabs) == 3
 
-                old_handle = self.browser.switch_to_window(has_three_tabs)
+                old_handle = self.windows.switch_to(has_three_tabs)
                 self.assertTrue(has_three_tabs())
 
                 # return to the original window
-                self.browser.switch_to_window(old_handle)
+                self.windows.switch_to(old_handle)
         """
         if isinstance(target, self.WindowElement):
             return target.switch_to()
@@ -66,7 +65,7 @@ class Browser(BaseLib):
             # switch if callback returns true. This is useful for when you want to, e.g,
             # switch to the window that contains a certain element.
             old_handle = self.client.current_window_handle
-            for window in self.windows:
+            for window in self.all:
                 window.switch_to()
                 if target():
                     return old_handle


### PR DESCRIPTION
This PR is the first patch for issue #18 to refactor the lib into general window handling code and ui specific classes. @ahal what do you think?
