### PR TITLE
modifications to fix tests since changing window handles to tlbcs; fixes...

### DIFF
--- a/greenlight/lib/tests/test_tabs.py
+++ b/greenlight/lib/tests/test_tabs.py
@@ -48,7 +48,7 @@ class TestTabs(FirefoxTestCase):
         """)
         self.prefs.restore_pref('browser.tabs.warnOnClose')
         self.prefs.restore_pref('browser.tabs.warnOnCloseOtherTabs')
-
+        self.wait_for_condition(lambda _: len(self.browser.tabbar.tabs) == 1)
         FirefoxTestCase.tearDown(self)
 
     def test_switch_to_tab(self):


### PR DESCRIPTION
... 29

This gets tests passing again, but doesn't integrate window switching/handling with our ui libraries nicely at all. I'm thinking we could have something like "find_opened_window()" in the browser class or a neighboring class that would return the new window handle when taking an action that results in a window opening to avoid the tedious pattern I have here. @whimboo, what do you think?
