### PR TITLE
Fix regression in using chrome_window_handle (#45)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,12 @@ before_install:
     - "/sbin/start-stop-daemon --start --quiet --make-pidfile --pidfile /tmp/custom_xvfb_99.pid --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1024x768x24"
 
 install:
-    - sudo apt-get install flashplugin-nonfree
+    - sudo apt-get install flashplugin-nonfree svn
+
+    # As long as we have invasive changes lets get the trunk version of marionette-client
+    - svn checkout https://github.com/mozilla/gecko-dev/trunk/testing/marionette/client
+    - "cd client && python setup develop && cd .."
+
     - python setup.py develop
     - pip install mozdownload pep8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
     - "/sbin/start-stop-daemon --start --quiet --make-pidfile --pidfile /tmp/custom_xvfb_99.pid --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1024x768x24"
 
 install:
-    - sudo apt-get install flashplugin-nonfree svn
+    - sudo apt-get install flashplugin-nonfree subversion
 
     # As long as we have invasive changes lets get the trunk version of marionette-client
     - svn checkout https://github.com/mozilla/gecko-dev/trunk/testing/marionette/client

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
 
     # As long as we have invasive changes lets get the trunk version of marionette-client
     - svn checkout https://github.com/mozilla/gecko-dev/trunk/testing/marionette/client
-    - "cd client && python setup develop && cd .."
+    - "cd client && python setup.py develop && cd .."
 
     - python setup.py develop
     - pip install mozdownload pep8

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_script:
 
     # Download Firefox Nightly which is compatible with the used version of
     # marionette client
-    - mozdownload -t daily --date 2014-12-18
+    - mozdownload -t daily
     - tar -xvf *firefox*.tar.bz2
 
 script:

--- a/greenlight/lib/api/windows.py
+++ b/greenlight/lib/api/windows.py
@@ -17,7 +17,7 @@ class Windows(BaseLib):
         :returns: a list of :class:`BaseWindow`'s corresponding to the
                   windows in `marionette.window_handles`.
         """
-        old_handle = self.marionette.chrome_window_handle
+        old_handle = self.marionette.current_chrome_window_handle
         windows = []
         for handle in self.marionette.chrome_window_handles:
             self.marionette.switch_to_window(handle)
@@ -71,7 +71,7 @@ class Windows(BaseLib):
         elif callable(target):
             # switch if callback returns true. This is useful for when you want
             # to, e.g. switch to the window that contains a certain element.
-            old_handle = self.marionette.chrome_window_handle
+            old_handle = self.marionette.current_chrome_window_handle
             for window in self.all:
                 window.switch_to()
                 if target(window):

--- a/greenlight/lib/tests/test_windows.py
+++ b/greenlight/lib/tests/test_windows.py
@@ -27,11 +27,11 @@ class TestWindows(FirefoxTestCase):
 
         self.windows.switch_to(windows[1])
         self.assertEquals(windows[1].handle,
-                          self.marionette.chrome_window_handle)
+                          self.marionette.current_chrome_window_handle)
 
         self.windows.switch_to(windows[2].handle)
         self.assertEquals(windows[2].handle,
-                          self.marionette.chrome_window_handle)
+                          self.marionette.current_chrome_window_handle)
 
         def is_my_window(win):
             with self.marionette.using_context('content'):
@@ -39,7 +39,7 @@ class TestWindows(FirefoxTestCase):
 
         self.windows.switch_to(is_my_window)
         self.assertEquals(windows[0].handle,
-                          self.marionette.chrome_window_handle)
+                          self.marionette.current_chrome_window_handle)
 
         with self.assertRaises(NoSuchElementException):
             self.windows.switch_to("humbug")
@@ -56,7 +56,7 @@ class TestWindows(FirefoxTestCase):
 
         first_window = self.windows.current
         self.assertEquals(first_window.handle,
-                          self.marionette.chrome_window_handle)
+                          self.marionette.current_chrome_window_handle)
         self.assertEquals(first_window.get_attribute('windowtype'),
                           self.marionette.get_window_type())
         self.assertEquals(first_window.window,
@@ -78,7 +78,7 @@ class TestWindows(FirefoxTestCase):
 
         first_window.switch_to()
         self.assertEquals(first_window.handle,
-                          self.marionette.chrome_window_handle)
+                          self.marionette.current_chrome_window_handle)
 
         self.assertFalse(second_window.closed)
         second_window.close()
@@ -87,7 +87,7 @@ class TestWindows(FirefoxTestCase):
         self.assertEquals(len(self.windows.all), 1)
         self.assertEquals(len(self.marionette.chrome_window_handles), 1)
         self.assertEquals(first_window.handle,
-                          self.marionette.chrome_window_handle)
+                          self.marionette.current_chrome_window_handle)
 
     def test_browser_window(self):
         self.assertNotEqual(self.browser.dtds, [])

--- a/greenlight/lib/ui/base_window.py
+++ b/greenlight/lib/ui/base_window.py
@@ -30,7 +30,7 @@ class BaseWindow(DOMElement):
     def __init__(self, element):
         DOMElement.__init__(self, element)
 
-        self.handle = self.marionette.chrome_window_handle
+        self.handle = self.marionette.current_chrome_window_handle
         self.l10n = L10n(self.get_marionette)
 
     @property
@@ -119,7 +119,7 @@ class BaseWindow(DOMElement):
 
     def switch_to(self):
         """Switches to this browser window."""
-        old_handle = self.marionette.chrome_window_handle
+        old_handle = self.marionette.current_chrome_window_handle
         if self.handle != old_handle:
             self.marionette.switch_to_window(self.handle)
 


### PR DESCRIPTION
With [bug 1114793](https://bugzilla.mozilla.org/show_bug.cgi?id=1114793) the Marionette class no longer has a `chrome_window_handle` property. This is available as `current_chrome_window_handle` now. This PR will fix the problems.