### PR TITLE
Add e10s to default prefs in the runner, skip tests navigating to about:...

### DIFF
--- a/firefox_puppeteer/__init__.py
+++ b/firefox_puppeteer/__init__.py
@@ -57,6 +57,14 @@ class Puppeteer(object):
         See the :class:`~api.prefs.Preferences` reference.
         """
 
+    @use_class_as_property('api.appinfo.AppInfo')
+    def appinfo(self):
+        """
+        Provides access to members of the appinfo  api.
+
+        See the :class:`~api.appinfo.AppInfo` reference.
+        """
+
 
 class DOMElement(HTMLElement):
     """

--- a/firefox_puppeteer/api/appinfo.py
+++ b/firefox_puppeteer/api/appinfo.py
@@ -1,0 +1,22 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from ..base import BaseLib
+
+
+class AppInfo(BaseLib):
+
+    @property
+    def browserTabsRemoteAutostart(self):
+        return self._get_property("browserTabsRemoteAutostart")
+
+    def _get_property(self, prop_name):
+        with self.marionette.using_context('chrome'):
+            return self.marionette.execute_script("""
+              try {
+                return Services.appinfo[arguments[0]];
+              } catch (e) {
+                return null;
+              }
+            """, script_args=[prop_name])

--- a/firefox_puppeteer/docs/api/appinfo.rst
+++ b/firefox_puppeteer/docs/api/appinfo.rst
@@ -1,0 +1,15 @@
+.. py:currentmodule:: firefox_puppeteer.api.appinfo
+
+AppInfo
+=======
+
+The appinfo class is a wrapper around the nsIXULAppInfo_ interface in
+Firefox and provides access to a subset of its members.
+
+.. _nsIXULAppInfo: https://developer.mozilla.org/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIXULAppInfo
+
+API reference
+-------------
+
+.. autoclass:: AppInfo
+   :members:

--- a/firefox_puppeteer/docs/index.rst
+++ b/firefox_puppeteer/docs/index.rst
@@ -43,6 +43,7 @@ future. Each library is available from an instance of the FirefoxTestCase class.
    ui/menu
    ui/navbar
    ui/tabbar
+   api/appinfo
    api/keys
    api/l10n
    api/prefs

--- a/firefox_puppeteer/tests/test_l10n.py
+++ b/firefox_puppeteer/tests/test_l10n.py
@@ -5,6 +5,7 @@
 from marionette.errors import MarionetteException
 
 from firefox_puppeteer.api.l10n import L10n
+from firefox_ui_harness.decorators import skip_if_e10s
 from firefox_ui_harness.testcase import FirefoxTestCase
 
 
@@ -29,6 +30,8 @@ class TestL10n(FirefoxTestCase):
                           self.l10n.get_localized_entity,
                           dtds, 'notExistent')
 
+    # Test navigates between remote and non remote pages (bug 1096488)
+    @skip_if_e10s
     def test_dtd_entity_content(self):
         dtds = ['chrome://global/locale/filepicker.dtd',
                 'chrome://global/locale/aboutSupport.dtd']

--- a/firefox_ui_harness/decorators.py
+++ b/firefox_ui_harness/decorators.py
@@ -1,0 +1,15 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from marionette import SkipTest
+
+from firefox_puppeteer.api import appinfo
+
+
+def skip_if_e10s(target):
+    def wrapper(self, *args, **kwargs):
+        if self.appinfo.browserTabsRemoteAutostart:
+            raise SkipTest("Skipping due to e10s")
+        return target(self, *args, **kwargs)
+    return wrapper

--- a/firefox_ui_harness/runtests.py
+++ b/firefox_ui_harness/runtests.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import copy
 import sys
 
 from marionette import BaseMarionetteTestRunner
@@ -14,10 +15,19 @@ from .testcase import FirefoxTestCase
 
 
 class ReleaseTestRunner(BaseMarionetteTestRunner):
+    extra_prefs = {
+        "browser.tabs.remote.autostart": True,
+    }
 
     def __init__(self, *args, **kwargs):
         if not kwargs.get('server_root'):
             kwargs['server_root'] = firefox_ui_tests.resources
+
+        prefs = kwargs.get('prefs', {})
+        extra_prefs = copy.deepcopy(ReleaseTestRunner.extra_prefs)
+        extra_prefs.update(prefs)
+        kwargs['prefs'] = extra_prefs
+
         BaseMarionetteTestRunner.__init__(self, *args, **kwargs)
         self.test_handlers = [FirefoxTestCase]
 

--- a/firefox_ui_tests/functional/keyboard_shortcuts/test_browser_window.py
+++ b/firefox_ui_tests/functional/keyboard_shortcuts/test_browser_window.py
@@ -2,19 +2,19 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from firefox_ui_harness.decorators import skip_if_e10s
 from firefox_ui_harness.testcase import FirefoxTestCase
 
 
 class TestBrowserWindowShortcuts(FirefoxTestCase):
 
-    def setUp(self):
-        FirefoxTestCase.setUp(self)
-
+    # Test navigates between remote and non remote pages (bug 1096488)
+    @skip_if_e10s
+    def test_addons_manager(self):
         # If an about:xyz page is visible, no new tab will be opened
         with self.marionette.using_context('content'):
             self.marionette.navigate('about:')
 
-    def test_addons_manager(self):
         key = self.browser.get_localized_entity('addons.commandkey')
 
         num_tabs = len(self.browser.tabbar.tabs)

--- a/firefox_ui_tests/functional/private_browsing/test_about_private_browsing.py
+++ b/firefox_ui_tests/functional/private_browsing/test_about_private_browsing.py
@@ -4,6 +4,7 @@
 
 from marionette import By, errors
 
+from firefox_ui_harness.decorators import skip_if_e10s
 from firefox_ui_harness.testcase import FirefoxTestCase
 
 
@@ -15,10 +16,9 @@ class TestAboutPrivateBrowsing(FirefoxTestCase):
                                                    'about.html?')
 
     def tearDown(self):
-        self.prefs.restore_pref('app.support.baseURL')
-
         self.marionette.close()
 
+    @skip_if_e10s
     def testCheckAboutPrivateBrowsing(self):
         self.assertFalse(self.browser.is_private)
 


### PR DESCRIPTION
... pages.