### PR TITLE
Bug 1127823 - Make use of unique parameter types in close_all() of Windows class

### DIFF
--- a/firefox_puppeteer/tests/test_windows.py
+++ b/firefox_puppeteer/tests/test_windows.py
@@ -119,7 +119,7 @@ class TestWindows(FirefoxTestCase):
         # Check for an unexpected window class
         self.assertRaises(errors.UnexpectedWindowTypeError,
                           win1.open_window, expected_window_class=BaseWindow)
-        self.windows.close_all([BaseWindow(lambda: self.marionette, win1.handle)])
+        self.windows.close_all([win1])
 
     def test_base_window_switch_to_and_focus(self):
         # force BaseWindow instance

--- a/firefox_puppeteer/tests/test_windows.py
+++ b/firefox_puppeteer/tests/test_windows.py
@@ -51,7 +51,7 @@ class TestWindows(FirefoxTestCase):
         self.assertRaises(NoSuchWindowException,
                           self.windows.switch_to, lambda win: False)
 
-        self.windows.close_all(self.browser)
+        self.windows.close_all([self.browser])
         self.browser.switch_to()
 
         self.assertEqual(len(self.windows.all), 1)
@@ -119,7 +119,7 @@ class TestWindows(FirefoxTestCase):
         # Check for an unexpected window class
         self.assertRaises(errors.UnexpectedWindowTypeError,
                           win1.open_window, expected_window_class=BaseWindow)
-        self.windows.close_all([win1.handle])
+        self.windows.close_all([BaseWindow(lambda: self.marionette, win1.handle)])
 
     def test_base_window_switch_to_and_focus(self):
         # force BaseWindow instance

--- a/firefox_puppeteer/ui/windows.py
+++ b/firefox_puppeteer/ui/windows.py
@@ -60,17 +60,18 @@ class Windows(BaseLib):
         # TODO: Maybe needs to wait as handled via an observer
         return self.marionette.close_chrome_window()
 
-    def close_all(self, exceptions=[]):
+    def close_all(self, exceptions=None):
         """Closes all open chrome windows.
 
         There is an optional `exceptions` list, which can be used to exclude
         specific chrome windows from being closed.
 
-        :param exceptions: Optional, list of :class:`BaseWindow` instances
-                           not to close
+        :param exceptions: Optional, list of :class:`BaseWindow` instances not to close
         """
-        # Get handles of BaseWindow instances in exceptions
-        handles_to_keep = [entry.handle for entry in exceptions]
+        windows_to_keep = exceptions or []
+
+        # Get handles of windows_to_keep
+        handles_to_keep = [entry.handle for entry in windows_to_keep]
 
         # Find handles to close and close them all
         handles_to_close = set(self.marionette.chrome_window_handles) - set(handles_to_keep)

--- a/firefox_puppeteer/ui/windows.py
+++ b/firefox_puppeteer/ui/windows.py
@@ -60,22 +60,17 @@ class Windows(BaseLib):
         # TODO: Maybe needs to wait as handled via an observer
         return self.marionette.close_chrome_window()
 
-    def close_all(self, exceptions=None):
+    def close_all(self, exceptions=[]):
         """Closes all open chrome windows.
 
         There is an optional `exceptions` list, which can be used to exclude
         specific chrome windows from being closed.
 
-        :param exceptions: Optional, list or a single entry of handles or
-         :class:`BaseWindow` instances not to close
+        :param exceptions: Optional, list of :class:`BaseWindow` instances
+                           not to close
         """
-        handles_to_keep = exceptions or []
-        if not isinstance(handles_to_keep, list):
-            handles_to_keep = [handles_to_keep]
-
-        # Ensure we only have handles and no BaseWindow entries
-        handles_to_keep = [entry.handle if isinstance(entry, BaseWindow) else entry
-                           for entry in handles_to_keep]
+        # Get handles of BaseWindow instances in exceptions
+        handles_to_keep = [entry.handle for entry in exceptions]
 
         # Find handles to close and close them all
         handles_to_close = set(self.marionette.chrome_window_handles) - set(handles_to_keep)


### PR DESCRIPTION
I am sympathetic both to Henrik's suggestion that close_all should expect a particular parameter type and to Chris’s distaste for APIs that convert a single element to a list, so I've implemented both here, in case that's what everybody wants after all.