### PR TITLE
Fix the link to the virtualenv installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Installation
 
 First make sure you have [pip](http://pip.readthedocs.org/en/latest/installing.html) installed.
 
-It is recommended that [virtualenv](http://virtualenv.readthedocs.org/en/latest/virtualenv.html#installation) and [virtualenvwrapper](http://virtualenvwrapper.readthedocs.org/en/latest/) be used in conjunction with firefox-ui-tests. Start by installing these.
+It is recommended that [virtualenv](http://virtualenv.readthedocs.org/en/latest/installation.html) and [virtualenvwrapper](http://virtualenvwrapper.readthedocs.org/en/latest/) be used in conjunction with firefox-ui-tests. Start by installing these.
 
 Then:
 


### PR DESCRIPTION
http://virtualenv.readthedocs.org/en/latest/installation.html is the correct, new link - http://virtualenv.readthedocs.org/en/latest/virtualenv.html#installation is a 404