### PR TITLE
Bug 1131181 - Add focusmanager.testmode: true to default prefs for firefox-ui-tests

### DIFF
--- a/firefox_puppeteer/ui/windows.py
+++ b/firefox_puppeteer/ui/windows.py
@@ -44,7 +44,7 @@ class Windows(BaseLib):
         with self.marionette.using_context('chrome'):
             return self.marionette.execute_script("""
               Cu.import("resource://gre/modules/Services.jsm");
-              var win = Services.wm.getMostRecentWindow("");
+              var win = Services.focus.activeWindow;
               return win.QueryInterface(Ci.nsIInterfaceRequestor)
                         .getInterface(Ci.nsIDOMWindowUtils)
                         .outerWindowID.toString();

--- a/firefox_ui_harness/default_prefs.py
+++ b/firefox_ui_harness/default_prefs.py
@@ -36,7 +36,7 @@ default_prefs = {
     'extensions.showMismatchUI': False,
     'extensions.update.enabled': False,
     'extensions.update.notifyUser': False,
-    'focusmanager.testmode': False,
+    'focusmanager.testmode': True,
     'geo.provider.testing': True,
     'javascript.options.showInConsole': True,
     'security.notification_enable_delay': 0,


### PR DESCRIPTION
Hi @whimboo!

Per today's discussion of focusmanager.testmode...

Not sure whether I ought to file a bug in bugzilla.