### PR TITLE
Bug 1131223 - Add teardown to Firefox Puppeteer's test_windows. r=hskupin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,5 +34,5 @@ script:
 notifications:
 #      email:
 #          - dev-automation@lists.mozilla.org
-    irc:
-        - "irc.mozilla.org#automation"
+#    irc:
+#        - "irc.mozilla.org#automation"

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,5 +34,5 @@ script:
 notifications:
 #      email:
 #          - dev-automation@lists.mozilla.org
-#    irc:
-#        - "irc.mozilla.org#automation"
+    irc:
+        - "irc.mozilla.org#automation"

--- a/firefox_puppeteer/tests/test_windows.py
+++ b/firefox_puppeteer/tests/test_windows.py
@@ -13,6 +13,10 @@ from firefox_puppeteer.ui.windows import BaseWindow
 
 class TestWindows(FirefoxTestCase):
 
+    def tearDown(self):
+        self.windows.close_all([self.browser])
+        FirefoxTestCase.tearDown(self)
+
     def test_windows(self):
         url = self.marionette.absolute_url('layout/mozilla')
 

--- a/firefox_puppeteer/tests/test_windows.py
+++ b/firefox_puppeteer/tests/test_windows.py
@@ -14,8 +14,10 @@ from firefox_puppeteer.ui.windows import BaseWindow
 class TestWindows(FirefoxTestCase):
 
     def tearDown(self):
-        self.windows.close_all([self.browser])
-        FirefoxTestCase.tearDown(self)
+        try:
+            self.windows.close_all([self.browser])
+        finally:
+            FirefoxTestCase.tearDown(self)
 
     def test_windows(self):
         url = self.marionette.absolute_url('layout/mozilla')


### PR DESCRIPTION
Without an appropriate tearDown, errors in one test in test_windows can cascade to cause error or failure in others.

https://bugzilla.mozilla.org/show_bug.cgi?id=1131223