### PR TITLE
Temporary fix for failing test_base_window_switch_to_and_focus

### DIFF
--- a/firefox_ui_harness/default_prefs.py
+++ b/firefox_ui_harness/default_prefs.py
@@ -36,6 +36,7 @@ default_prefs = {
     'extensions.showMismatchUI': False,
     'extensions.update.enabled': False,
     'extensions.update.notifyUser': False,
+    'focusmanager.testmode': False,
     'geo.provider.testing': True,
     'javascript.options.showInConsole': True,
     'security.notification_enable_delay': 0,


### PR DESCRIPTION
Sets focusmanager.testmode False for now (since the pref got added to Marionette)