### PR TITLE
Bug 1132682 - Convert Mozmill test 'remote/testSecurity/testMixedContentPage.js' to Marionette r=jmaher, chmanchester

### DIFF
--- a/firefox_ui_tests/manifest.ini
+++ b/firefox_ui_tests/manifest.ini
@@ -1,2 +1,3 @@
 [include:functional/manifest.ini]
 [include:remote/manifest.ini]
+

--- a/firefox_ui_tests/remote/security/manifest.ini
+++ b/firefox_ui_tests/remote/security/manifest.ini
@@ -7,3 +7,4 @@
 [test_ssl_disabled_error_page.py]
 [test_submit_unencrypted_info_warning.py]
 [test_unknown_issuer.py]
+[test_untrusted_connection_error_page.py]

--- a/firefox_ui_tests/remote/security/manifest.ini
+++ b/firefox_ui_tests/remote/security/manifest.ini
@@ -9,3 +9,4 @@
 [test_unknown_issuer.py]
 [test_untrusted_connection_error_page.py]
 [test_mixed_content.py]
+

--- a/firefox_ui_tests/remote/security/manifest.ini
+++ b/firefox_ui_tests/remote/security/manifest.ini
@@ -7,6 +7,5 @@
 [test_ssl_disabled_error_page.py]
 [test_submit_unencrypted_info_warning.py]
 [test_unknown_issuer.py]
-[test_untrusted_connection_error_page.py]
 [test_mixed_content.py]
 

--- a/firefox_ui_tests/remote/security/manifest.ini
+++ b/firefox_ui_tests/remote/security/manifest.ini
@@ -8,3 +8,4 @@
 [test_submit_unencrypted_info_warning.py]
 [test_unknown_issuer.py]
 [test_untrusted_connection_error_page.py]
+[test_mixed_content.py]

--- a/firefox_ui_tests/remote/security/manifest.ini
+++ b/firefox_ui_tests/remote/security/manifest.ini
@@ -1,5 +1,6 @@
 [test_dv_certificate.py]
 [test_ev_certificate.py]
+[test_mixed_content.py]
 [test_mixed_script_content_blocking.py]
 [test_safe_browsing_notification.py]
 [test_safe_browsing_warning_pages.py]
@@ -7,5 +8,3 @@
 [test_ssl_disabled_error_page.py]
 [test_submit_unencrypted_info_warning.py]
 [test_unknown_issuer.py]
-[test_mixed_content.py]
-

--- a/firefox_ui_tests/remote/security/test_mixed_content.py
+++ b/firefox_ui_tests/remote/security/test_mixed_content.py
@@ -15,14 +15,12 @@ class TestMixedContent(FirefoxTestCase):
         with self.marionette.using_context('content'):
             self.marionette.navigate(self.test_url)
 
-        favicon = self.browser.navbar.locationbar.favicon
-
-        def check_favicon_image(self):
+        def check_favicon_image(mn):
             favicon_image = self.execute_script("\
                 return arguments[0].ownerDocument.defaultView\
                                    .getComputedStyle(arguments[0])\
                                    .getPropertyValue('list-style-image');\
-            ", script_args=[favicon])
+            ", script_args=[self.browser.navbar.locationbar.favicon])
             return 'identity-icons-https-mixed-display' in favicon_image
 
         self.wait_for_condition(check_favicon_image)

--- a/firefox_ui_tests/remote/security/test_mixed_content.py
+++ b/firefox_ui_tests/remote/security/test_mixed_content.py
@@ -14,27 +14,22 @@ class TestMixedContent(FirefoxTestCase):
     def test_mixed_content(self):
         with self.marionette.using_context('content'):
             self.marionette.navigate(self.test_url)
+
         favicon = self.browser.navbar.locationbar.favicon
 
         def check_favicon_image(self):
-            favicon_image = self.execute_script("""
-                return arguments[0].ownerDocument.defaultView
-                                   .getComputedStyle(arguments[0])
-                                   .getPropertyValue('list-style-image');
-            """, script_args=[favicon])
-            return "identity-icons-https-mixed-display" in favicon_image
+            favicon_image = self.execute_script("\
+                return arguments[0].ownerDocument.defaultView\
+                                   .getComputedStyle(arguments[0])\
+                                   .getPropertyValue('list-style-image');\
+            ", script_args=[favicon])
+            return 'identity-icons-https-mixed-display' in favicon_image
 
         self.wait_for_condition(check_favicon_image)
 
         identity_popup = self.browser.navbar.locationbar.identity_popup
-        identity_box = identity_popup.box
-        identity_box.click()
+        identity_popup.box.click()
 
-        def identity_popup_displayed(self):
-            return identity_popup.popup.is_displayed()
-
-        self.wait_for_condition(identity_popup_displayed)
-        encryption_label = identity_popup.encryption_label
-        label_text = encryption_label.text
-        prop = self.browser.get_property('identity.broken_loaded')
-        self.assertEqual(label_text, prop)
+        self.wait_for_condition(lambda _: identity_popup.popup.is_displayed())
+        self.assertEqual(identity_popup.encryption_label.text,
+                         self.browser.get_property('identity.broken_loaded'))

--- a/firefox_ui_tests/remote/security/test_mixed_content.py
+++ b/firefox_ui_tests/remote/security/test_mixed_content.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from firefox_ui_harness.testcase import FirefoxTestCase
+from marionette_driver import Wait
 
 
 class TestMixedContent(FirefoxTestCase):
@@ -11,15 +12,29 @@ class TestMixedContent(FirefoxTestCase):
 
         self.url = 'https://mozqa.com/data/firefox/security/mixedcontent.html'
 
+    def tearDown(self):
+        try:
+            if self.browser.navbar.locationbar.identity_popup.is_open:
+                self.browser.navbar.locationbar.identity_popup.close(force=True)
+        finally:
+            FirefoxTestCase.tearDown(self)
+
     def test_mixed_content(self):
         with self.marionette.using_context('content'):
             self.marionette.navigate(self.url)
 
-        self.assertTrue('identity-icons-https-mixed-display' in
-                        self.navbar.locationbar.favicon.value_of_css_property('list-style-image'))
-        identity_popup = self.navbar.locationbar.identity_popup
+        favicon = self.browser.navbar.locationbar.favicon
+        self.wait_for_condition(lambda _: favicon.get_attribute('hidden') != 'none')
+        self.assertTrue("identity-icons-https-mixed-display" in
+                        favicon.value_of_css_property('list-style-image'))
+
+        identity_popup = self.browser.navbar.locationbar.identity_popup
         identity_popup.box.click()
 
-        self.wait_for_condition(lambda _: identity_popup.popup.is_displayed())
+        Wait(self.marionette).until(lambda _: identity_popup.is_open)
+
         self.assertEqual(identity_popup.encryption_label.text,
                          self.browser.get_property('identity.broken_loaded'))
+
+        identity_popup.close(force=True)
+        self.assertFalse(identity_popup.is_open)

--- a/firefox_ui_tests/remote/security/test_mixed_content.py
+++ b/firefox_ui_tests/remote/security/test_mixed_content.py
@@ -1,8 +1,9 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
+from firefox_ui_harness.decorators import skip_under_xvfb
 from firefox_ui_harness.testcase import FirefoxTestCase
+
 from marionette_driver import Wait
 
 
@@ -13,18 +14,21 @@ class TestMixedContent(FirefoxTestCase):
         self.url = 'https://mozqa.com/data/firefox/security/mixedcontent.html'
 
     def tearDown(self):
-        try:
-            if self.browser.navbar.locationbar.identity_popup.is_open:
-                self.browser.navbar.locationbar.identity_popup.close(force=True)
-        finally:
-            FirefoxTestCase.tearDown(self)
+        self.browser.navbar.locationbar.identity_popup.close(force=True)
+        FirefoxTestCase.tearDown(self)
 
+    @skip_under_xvfb
     def test_mixed_content(self):
         with self.marionette.using_context('content'):
             self.marionette.navigate(self.url)
 
         favicon = self.browser.navbar.locationbar.favicon
-        Wait(self.marionette).until(lambda _: favicon.get_attribute('hidden') != 'none')
+
+        favicon_hidden = self.marionette.execute_script("""
+          return arguments[0].hasAttribute("hidden");
+        """, script_args=[favicon])
+        self.assertFalse(favicon_hidden, 'The page proxy favicon should be visible')
+
         self.assertTrue("identity-icons-https-mixed-display" in
                         favicon.value_of_css_property('list-style-image'))
 
@@ -36,5 +40,4 @@ class TestMixedContent(FirefoxTestCase):
         self.assertEqual(identity_popup.encryption_label.text,
                          self.browser.get_property('identity.broken_loaded'))
 
-        identity_popup.close(force=True)
-        self.assertFalse(identity_popup.is_open)
+        identity_popup.close()

--- a/firefox_ui_tests/remote/security/test_mixed_content.py
+++ b/firefox_ui_tests/remote/security/test_mixed_content.py
@@ -24,7 +24,7 @@ class TestMixedContent(FirefoxTestCase):
             self.marionette.navigate(self.url)
 
         favicon = self.browser.navbar.locationbar.favicon
-        self.wait_for_condition(lambda _: favicon.get_attribute('hidden') != 'none')
+        Wait(self.marionette).until(lambda _: favicon.get_attribute('hidden') != 'none')
         self.assertTrue("identity-icons-https-mixed-display" in
                         favicon.value_of_css_property('list-style-image'))
 

--- a/firefox_ui_tests/remote/security/test_mixed_content.py
+++ b/firefox_ui_tests/remote/security/test_mixed_content.py
@@ -36,8 +36,5 @@ class TestMixedContent(FirefoxTestCase):
         self.wait_for_condition(identity_popup_displayed)
         encryption_label = identity_popup.encryption_label
         label_text = encryption_label.text
-        prop = self.browser._l10n.get_property(
-            ['chrome://browser/locale/browser.properties'],
-            'identity.broken_loaded'
-            )
+        prop = self.browser.get_property('identity.broken_loaded')
         self.assertEqual(label_text, prop)

--- a/firefox_ui_tests/remote/security/test_mixed_content.py
+++ b/firefox_ui_tests/remote/security/test_mixed_content.py
@@ -16,7 +16,7 @@ class TestMixedContent(FirefoxTestCase):
             self.marionette.navigate(self.test_url)
 
         def check_favicon_image(mn):
-            favicon_image = self.execute_script("\
+            favicon_image = mn.execute_script("\
                 return arguments[0].ownerDocument.defaultView\
                                    .getComputedStyle(arguments[0])\
                                    .getPropertyValue('list-style-image');\

--- a/firefox_ui_tests/remote/security/test_mixed_content.py
+++ b/firefox_ui_tests/remote/security/test_mixed_content.py
@@ -1,0 +1,43 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from firefox_ui_harness.testcase import FirefoxTestCase
+
+
+class TestMixedContent(FirefoxTestCase):
+    def setUp(self):
+        FirefoxTestCase.setUp(self)
+
+        self.test_url = 'https://mozqa.com/data/firefox/security/mixedcontent.html'
+
+    def test_mixed_content(self):
+        with self.marionette.using_context('content'):
+            self.marionette.navigate(self.test_url)
+        favicon = self.browser.navbar.locationbar.favicon
+
+        def check_favicon_image(self):
+            favicon_image = self.execute_script("""
+                return arguments[0].ownerDocument.defaultView
+                                   .getComputedStyle(arguments[0])
+                                   .getPropertyValue('list-style-image');
+            """, script_args=[favicon])
+            return "identity-icons-https-mixed-display" in favicon_image
+
+        self.wait_for_condition(check_favicon_image)
+
+        identity_popup = self.browser.navbar.locationbar.identity_popup
+        identity_box = identity_popup.box
+        identity_box.click()
+
+        def identity_popup_displayed(self):
+            return identity_popup.popup.is_displayed()
+
+        self.wait_for_condition(identity_popup_displayed)
+        encryption_label = identity_popup.encryption_label
+        label_text = encryption_label.text
+        prop = self.browser._l10n.get_property(
+            ['chrome://browser/locale/browser.properties'],
+            'identity.broken_loaded'
+            )
+        self.assertEqual(label_text, prop)

--- a/firefox_ui_tests/remote/security/test_mixed_content.py
+++ b/firefox_ui_tests/remote/security/test_mixed_content.py
@@ -9,23 +9,15 @@ class TestMixedContent(FirefoxTestCase):
     def setUp(self):
         FirefoxTestCase.setUp(self)
 
-        self.test_url = 'https://mozqa.com/data/firefox/security/mixedcontent.html'
+        self.url = 'https://mozqa.com/data/firefox/security/mixedcontent.html'
 
     def test_mixed_content(self):
         with self.marionette.using_context('content'):
-            self.marionette.navigate(self.test_url)
+            self.marionette.navigate(self.url)
 
-        def check_favicon_image(mn):
-            favicon_image = mn.execute_script("\
-                return arguments[0].ownerDocument.defaultView\
-                                   .getComputedStyle(arguments[0])\
-                                   .getPropertyValue('list-style-image');\
-            ", script_args=[self.browser.navbar.locationbar.favicon])
-            return 'identity-icons-https-mixed-display' in favicon_image
-
-        self.wait_for_condition(check_favicon_image)
-
-        identity_popup = self.browser.navbar.locationbar.identity_popup
+        self.assertTrue('identity-icons-https-mixed-display' in
+                        self.navbar.locationbar.favicon.value_of_css_property('list-style-image'))
+        identity_popup = self.navbar.locationbar.identity_popup
         identity_popup.box.click()
 
         self.wait_for_condition(lambda _: identity_popup.popup.is_displayed())


### PR DESCRIPTION
Recreating pull request for : 
https://bugzilla.mozilla.org/show_bug.cgi?id=1132682
Bug 1132682 - Convert Mozmill test 'remote/testSecurity/testMixedContentPage.js' to Marionette

Sorry about this! I messed up rebases.
@chmanchester @jmaher 