### PR TITLE
Bug 1133753 - Convert Mozmill about-window.js library to Python/Marionette

### DIFF
--- a/firefox_puppeteer/docs/index.rst
+++ b/firefox_puppeteer/docs/index.rst
@@ -33,6 +33,7 @@ The following libraries are currently implemented. More will be added in the
 future. Each library is available from an instance of the FirefoxTestCase class.
 
 .. toctree::
+   ui/about/window
    ui/menu
    ui/pageinfo/window
    ui/tabbar

--- a/firefox_puppeteer/docs/ui/about_window/window.rst
+++ b/firefox_puppeteer/docs/ui/about_window/window.rst
@@ -14,3 +14,53 @@ Deck
 .. autoclass:: firefox_puppeteer.ui.about_window.deck.Deck
    :members:
    :inherited-members:
+
+ApplyBillboardPanel
+-------------------
+
+.. autoclass:: firefox_puppeteer.ui.about_window.deck.ApplyBillboardPanel
+   :members:
+   :inherited-members:
+
+ApplyPanel
+----------
+
+.. autoclass:: firefox_puppeteer.ui.about_window.deck.ApplyPanel
+   :members:
+   :inherited-members:
+
+CheckForUpdatesPanel
+--------------------
+
+.. autoclass:: firefox_puppeteer.ui.about_window.deck.CheckForUpdatesPanel
+   :members:
+   :inherited-members:
+
+CheckingForUpdatesPanel
+-----------------------
+
+.. autoclass:: firefox_puppeteer.ui.about_window.deck.CheckingForUpdatesPanel
+   :members:
+   :inherited-members:
+
+DownloadAndInstallPanel
+-----------------------
+
+.. autoclass:: firefox_puppeteer.ui.about_window.deck.DownloadAndInstallPanel
+   :members:
+   :inherited-members:
+
+DownloadFailedPanel
+-------------------
+
+.. autoclass:: firefox_puppeteer.ui.about_window.deck.DownloadFailedPanel
+   :members:
+   :inherited-members:
+
+DownloadingPanel
+----------------
+
+.. autoclass:: firefox_puppeteer.ui.about_window.deck.DownloadingPanel
+   :members:
+   :inherited-members:
+

--- a/firefox_puppeteer/docs/ui/about_window/window.rst
+++ b/firefox_puppeteer/docs/ui/about_window/window.rst
@@ -1,0 +1,16 @@
+About Window
+============
+
+AboutWindow
+--------------
+
+.. autoclass:: firefox_puppeteer.ui.about_window.window.AboutWindow
+   :members:
+   :inherited-members:
+
+Deck
+----
+
+.. autoclass:: firefox_puppeteer.ui.about_window.deck.Deck
+   :members:
+   :inherited-members:

--- a/firefox_puppeteer/docs/ui/windows.rst
+++ b/firefox_puppeteer/docs/ui/windows.rst
@@ -12,7 +12,3 @@ Windows
 .. autoclass:: BrowserWindow
    :members:
    :inherited-members:
-
-.. autoclass:: AboutWindow
-   :members:
-   :inherited-members:

--- a/firefox_puppeteer/docs/ui/windows.rst
+++ b/firefox_puppeteer/docs/ui/windows.rst
@@ -12,3 +12,7 @@ Windows
 .. autoclass:: BrowserWindow
    :members:
    :inherited-members:
+
+.. autoclass:: AboutWindow
+   :members:
+   :inherited-members:

--- a/firefox_puppeteer/tests/manifest.ini
+++ b/firefox_puppeteer/tests/manifest.ini
@@ -8,3 +8,4 @@
 [test_tabbar.py]
 [test_toolbars.py]
 [test_windows.py]
+[test_about_window.py]

--- a/firefox_puppeteer/tests/test_about_window.py
+++ b/firefox_puppeteer/tests/test_about_window.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from marionette import By
+from marionette_driver import By
 
 from firefox_ui_harness.testcase import FirefoxTestCase
 

--- a/firefox_puppeteer/tests/test_about_window.py
+++ b/firefox_puppeteer/tests/test_about_window.py
@@ -1,0 +1,63 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from marionette import By
+
+from firefox_ui_harness.testcase import FirefoxTestCase
+
+
+class TestAboutWindow(FirefoxTestCase):
+
+    def setUp(self):
+        FirefoxTestCase.setUp(self)
+
+        self.about_window = self.browser.open_about_window(trigger='menu')
+
+    def tearDown(self):
+        try:
+            self.windows.close_all([self.browser])
+        finally:
+            FirefoxTestCase.tearDown(self)
+
+    def test_basic(self):
+        self.assertEqual(self.about_window.window_type, 'Browser:About')
+
+    def test_check_for_updates_and_download(self):
+        # testing both of these as they need to occur in this order
+        self.about_window.check_for_updates()
+        self.assertEqual('downloadAndInstall', self.about_window.wizard_state)
+        self.about_window.download()
+        self.assertEqual('apply', self.about_window.wizard_state)
+
+    def test_close_window(self):
+        """Test closing the About window."""
+        self.about_window.close()
+        self.assertTrue(self.about_window.closed)
+
+    def test_open_window(self):
+        """Test various opening strategies."""
+        def opener(win):
+            menu = win.marionette.find_element(By.ID, 'aboutName')
+            menu.click()
+
+        open_strategies = ('menu',
+                           opener,
+                           )
+
+        for trigger in open_strategies:
+            if not self.about_window.closed:
+                self.about_window.close()
+            about_window = self.browser.open_about_window(trigger=trigger)
+            self.assertEquals(about_window, self.windows.current)
+            about_window.close()
+
+    def test_patch_info(self):
+        self.assertTrue(self.about_window.patch_info['download_duration'])
+        self.assertTrue(self.about_window.patch_info['channel'])
+
+    def test_updates_found(self):
+        self.assertTrue(self.about_window.updates_found)
+
+    def test_wizard_state(self):
+        self.assertTrue(self.about_window.wizard_state)

--- a/firefox_puppeteer/tests/test_about_window.py
+++ b/firefox_puppeteer/tests/test_about_window.py
@@ -12,7 +12,7 @@ class TestAboutWindow(FirefoxTestCase):
     def setUp(self):
         FirefoxTestCase.setUp(self)
 
-        self.about_window = self.browser.open_about_window(trigger='menu')
+        self.about_window = self.browser.open_about_window()
 
     def tearDown(self):
         try:
@@ -23,17 +23,52 @@ class TestAboutWindow(FirefoxTestCase):
     def test_basic(self):
         self.assertEqual(self.about_window.window_type, 'Browser:About')
 
-    def test_check_for_updates_and_download(self):
-        # testing both of these as they need to occur in this order
-        self.about_window.check_for_updates()
-        self.assertEqual('downloadAndInstall', self.about_window.wizard_state)
-        self.about_window.download()
-        self.assertEqual('apply', self.about_window.wizard_state)
+    def test_elements(self):
+        """Test correct retrieval of elements."""
+        self.assertNotEqual(self.about_window.dtds, [])
 
-    def test_close_window(self):
-        """Test closing the About window."""
-        self.about_window.close()
-        self.assertTrue(self.about_window.closed)
+        self.assertEqual(
+            self.about_window.deck.element.get_attribute('localName'),
+            'deck')
+
+        # apply panel
+        panel = self.about_window.deck.apply
+        self.assertEqual(panel.element.get_attribute('localName'), 'hbox')
+        self.assertEqual(panel.update_button.get_attribute('localName'), 'button')
+
+        # apply_billboard panel
+        panel = self.about_window.deck.apply_billboard
+        self.assertEqual(panel.element.get_attribute('localName'), 'hbox')
+        self.assertEqual(
+            panel.apply_billboard_button.get_attribute('localName'),
+            'button')
+
+        # check_for_updates panel
+        panel = self.about_window.deck.check_for_updates
+        self.assertEqual(panel.element.get_attribute('localName'), 'hbox')
+        self.assertEqual(
+            panel.check_for_updates_button.get_attribute('localName'),
+            'button')
+
+        # checking_for_updates panel
+        self.assertEqual(
+            self.about_window.deck.checking_for_updates.element.get_attribute('localName'),
+            'hbox')
+
+        # download_and_install panel
+        panel = self.about_window.deck.download_and_install
+        self.assertEqual(panel.element.get_attribute('localName'), 'hbox')
+        self.assertEqual(panel.download_button.get_attribute('localName'), 'button')
+
+        # download_failed panel
+        self.assertEqual(
+            self.about_window.deck.download_failed.element.get_attribute('localName'),
+            'hbox')
+
+        # downloading panel
+        self.assertEqual(
+            self.about_window.deck.downloading.element.get_attribute('localName'),
+            'hbox')
 
     def test_open_window(self):
         """Test various opening strategies."""
@@ -45,19 +80,12 @@ class TestAboutWindow(FirefoxTestCase):
                            opener,
                            )
 
+        self.about_window.close()
         for trigger in open_strategies:
-            if not self.about_window.closed:
-                self.about_window.close()
             about_window = self.browser.open_about_window(trigger=trigger)
             self.assertEquals(about_window, self.windows.current)
             about_window.close()
 
     def test_patch_info(self):
-        self.assertTrue(self.about_window.patch_info['download_duration'])
-        self.assertTrue(self.about_window.patch_info['channel'])
-
-    def test_updates_found(self):
-        self.assertTrue(self.about_window.updates_found)
-
-    def test_wizard_state(self):
-        self.assertTrue(self.about_window.wizard_state)
+        self.assertEqual(self.about_window.patch_info['download_duration'], -1)
+        self.assertNotEqual(self.about_window.patch_info['channel'], None)

--- a/firefox_puppeteer/tests/test_about_window.py
+++ b/firefox_puppeteer/tests/test_about_window.py
@@ -34,21 +34,17 @@ class TestAboutWindow(FirefoxTestCase):
         # apply panel
         panel = self.about_window.deck.apply
         self.assertEqual(panel.element.get_attribute('localName'), 'hbox')
-        self.assertEqual(panel.update_button.get_attribute('localName'), 'button')
+        self.assertEqual(panel.button.get_attribute('localName'), 'button')
 
         # apply_billboard panel
         panel = self.about_window.deck.apply_billboard
         self.assertEqual(panel.element.get_attribute('localName'), 'hbox')
-        self.assertEqual(
-            panel.apply_billboard_button.get_attribute('localName'),
-            'button')
+        self.assertEqual(panel.button.get_attribute('localName'), 'button')
 
         # check_for_updates panel
         panel = self.about_window.deck.check_for_updates
         self.assertEqual(panel.element.get_attribute('localName'), 'hbox')
-        self.assertEqual(
-            panel.check_for_updates_button.get_attribute('localName'),
-            'button')
+        self.assertEqual(panel.button.get_attribute('localName'), 'button')
 
         # checking_for_updates panel
         self.assertEqual(
@@ -58,17 +54,15 @@ class TestAboutWindow(FirefoxTestCase):
         # download_and_install panel
         panel = self.about_window.deck.download_and_install
         self.assertEqual(panel.element.get_attribute('localName'), 'hbox')
-        self.assertEqual(panel.download_button.get_attribute('localName'), 'button')
+        self.assertEqual(panel.button.get_attribute('localName'), 'button')
 
         # download_failed panel
-        self.assertEqual(
-            self.about_window.deck.download_failed.element.get_attribute('localName'),
-            'hbox')
+        self.assertEqual(self.about_window.deck.download_failed.element.get_attribute('localName'),
+                         'hbox')
 
         # downloading panel
-        self.assertEqual(
-            self.about_window.deck.downloading.element.get_attribute('localName'),
-            'hbox')
+        self.assertEqual(self.about_window.deck.downloading.element.get_attribute('localName'),
+                         'hbox')
 
     def test_open_window(self):
         """Test various opening strategies."""
@@ -88,4 +82,4 @@ class TestAboutWindow(FirefoxTestCase):
 
     def test_patch_info(self):
         self.assertEqual(self.about_window.patch_info['download_duration'], -1)
-        self.assertNotEqual(self.about_window.patch_info['channel'], None)
+        self.assertTrue(self.about_window.patch_info['channel'])

--- a/firefox_puppeteer/ui/about_window.py
+++ b/firefox_puppeteer/ui/about_window.py
@@ -1,0 +1,130 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from datetime import datetime
+
+from marionette import By, Wait
+
+from .windows import BaseWindow
+from ..api.software_update import SoftwareUpdate
+
+
+class AboutWindow(BaseWindow):
+    """Representation of the About window."""
+
+    TIMEOUT_UPDATE_APPLY = 300
+    TIMEOUT_UPDATE_CHECK = 30
+    TIMEOUT_UPDATE_DOWNLOAD = 360
+
+    window_type = 'Browser:About'
+
+    def __init__(self, marionette_getter, window_handle):
+        BaseWindow.__init__(self, marionette_getter, window_handle)
+
+        self.software_update = SoftwareUpdate(marionette_getter)
+        self.download_duration = -1
+
+    @property
+    def patch_info(self):
+        """ Returns information about the active update in the queue.
+
+        :returns: A dictionary with information about the active patch
+        """
+        patch = self.software_update.patch_info
+        patch['download_duration'] = self.download_duration
+        return patch
+
+    @property
+    def updates_found(self):
+        """ Checks if updates were found
+
+        :returns: True if updates were found
+        """
+
+        return self.wizard_state != 'noUpdatesFound'
+
+    @property
+    def wizard_state(self):
+        deck = self.marionette.find_element(By.ID, 'updateDeck')
+        return self.marionette.execute_script("""
+          return arguments[0].selectedPanel.id;
+        """, script_args=[deck])
+
+    def check_for_updates(self):
+        """Clicks on "Check for Updates" button, and waits for check to complete"""
+        Wait(self.marionette).until(
+            lambda _: self.wizard_state == 'checkForUpdates')
+        check_button = self.marionette.find_element(By.ID, 'checkForUpdatesButton')
+        check_button.click()
+
+        # Wait for the update checking to finish
+        Wait(self.marionette, self.TIMEOUT_UPDATE_CHECK).until(
+            lambda _: self.wizard_state != 'checkingForUpdates')
+
+    def download(self, wait_for_finish=True, timeout=TIMEOUT_UPDATE_DOWNLOAD):
+        """ Download the update
+
+        :param wait_for_finish: Should the function wait until the download has finished?
+        :param timeout: How long to wait for the download to finish
+        """
+        assert self.software_update.update_channel.default_channel ==\
+               self.software_update.update_channel.channel,\
+            'The update channel has been set correctly.'
+
+        if self.wizard_state == 'downloadAndInstall':
+            install_button = self.marionette.find_element(By.ID, 'downloadAndInstallButton')
+            install_button.click()
+
+        # Wait for the download to start
+        Wait(self.marionette).until(
+            lambda _: self.wizard_state != 'downloadAndInstall')
+
+        # If there are incompatible addons we fallback on old software update dialog for updating
+        if self.wizard_state == 'applyBillboard':
+            update_button = self.marionette.find_element(By.ID, 'updateButton')
+            update_button.click()
+
+            # The rest of the code inside this `if` uses the update wizard which is
+            # not being converted yet
+            #
+            # The current JS code is:
+            #
+            #     var wizard = updateWizard.handleUpdateWizardDialog();
+            #     wizard.waitForWizardPage(updateWizard.WIZARD_PAGES.updatesfoundbasic);
+            #     wizard.download();
+            #     wizard.close();
+            #     this._downloadDuration = wizard._downloadDuration;
+            #
+            #     return;
+
+        if wait_for_finish:
+            start_time = datetime.now()
+            self._wait_for_download_finished(timeout)
+            self.download_duration = datetime.now() - start_time
+
+    def _wait_for_download_finished(self, timeout):
+        """ Waits until download is completed
+
+        :param timeout: How long to wait for the download to complete
+        """
+
+        Wait(self.marionette, timeout).until(
+            lambda _: self.wizard_state != 'downloading',
+            message='Download has been completed.')
+
+        assert self.wizard_state != 'downloadFailed'
+
+    def wait_for_update_applied(self, timeout=TIMEOUT_UPDATE_APPLY):
+        """ Waits until the downloaded update has been applied
+
+        :param timeout: How long to wait for the update to apply
+        """
+
+        Wait(self.marionette, timeout).until(
+            lambda _: self.wizard_state == 'apply',
+            message='Final wizard page has been selected.')
+
+        Wait(self.marionette, timeout).until(
+            lambda _: 'applied' in self.software_update.active_update.state,
+            message='Update has been applied.')

--- a/firefox_puppeteer/ui/about_window/deck.py
+++ b/firefox_puppeteer/ui/about_window/deck.py
@@ -22,7 +22,7 @@ class Deck(UIBaseLib):
                    'checkingForUpdates': CheckingForUpdatesPanel,
                    'downloadAndInstall': DownloadAndInstallPanel,
                    'downloadFailed': DownloadFailedPanel,
-                   'downloading': ApplyBillboardPanel
+                   'downloading': DownloadingPanel
                    }
 
         panel = self.element.find_element(By.ID, panel_id)
@@ -137,10 +137,10 @@ class Panel(UIBaseLib):
 class ApplyBillboardPanel(Panel):
 
     @property
-    def apply_billboard_button(self):
+    def button(self):
         """The DOM element which represents the Apply Billboard button.
 
-        :returns: Reference to the textbox element.
+        :returns: Reference to the button element.
         """
         return self.element.find_element(By.ID, 'applyButtonBillboard')
 
@@ -148,10 +148,10 @@ class ApplyBillboardPanel(Panel):
 class ApplyPanel(Panel):
 
     @property
-    def update_button(self):
+    def button(self):
         """The DOM element which represents the Update button.
 
-        :returns: Reference to the textbox element.
+        :returns: Reference to the button element.
         """
         return self.element.find_element(By.ID, 'updateButton')
 
@@ -159,10 +159,10 @@ class ApplyPanel(Panel):
 class CheckForUpdatesPanel(Panel):
 
     @property
-    def check_for_updates_button(self):
+    def button(self):
         """The DOM element which represents the Check for Updates button.
 
-        :returns: Reference to the textbox element.
+        :returns: Reference to the button element.
         """
         return self.element.find_element(By.ID, 'checkForUpdatesButton')
 
@@ -174,10 +174,10 @@ class CheckingForUpdatesPanel(Panel):
 class DownloadAndInstallPanel(Panel):
 
     @property
-    def download_button(self):
+    def button(self):
         """The DOM element which represents the Download button.
 
-        :returns: Reference to the textbox element.
+        :returns: Reference to the button element.
         """
         return self.element.find_element(By.ID, 'downloadAndInstallButton')
 

--- a/firefox_puppeteer/ui/about_window/deck.py
+++ b/firefox_puppeteer/ui/about_window/deck.py
@@ -9,25 +9,182 @@ from ...base import UIBaseLib
 
 class Deck(UIBaseLib):
 
-    def _click_deck_button(self, element_id):
-        button = self.marionette.find_element(By.ID, element_id)
-        button.click()
+    def _create_panel_for_id(self, panel_id):
+        """Creates an instance of :class:`Panel` for the specified panel id.
+
+        :param panel_id: The ID of the panel to create an instance of.
+
+        :returns: :class:`Panel` instance
+        """
+        mapping = {'apply': ApplyPanel,
+                   'applyBillboard': ApplyBillboardPanel,
+                   'checkForUpdates': CheckForUpdatesPanel,
+                   'checkingForUpdates': CheckingForUpdatesPanel,
+                   'downloadAndInstall': DownloadAndInstallPanel,
+                   'downloadFailed': DownloadFailedPanel,
+                   'downloading': ApplyBillboardPanel
+                   }
+
+        panel = self.element.find_element(By.ID, panel_id)
+        return mapping.get(panel_id, Panel)(lambda: self.marionette, self.window, panel)
+
+    # Properties for visual elements of the deck #
 
     @property
-    def wizard_state(self):
-        """ Returns the current state of the update wizard."""
-        return self.marionette.execute_script("""
-          return arguments[0].selectedPanel.id;
+    def apply(self):
+        """The :class:`ApplyPanel` instance for the apply panel.
+
+        :returns: :class:`ApplyPanel` instance.
+        """
+        return self._create_panel_for_id('apply')
+
+    @property
+    def apply_billboard(self):
+        """The :class:`ApplyBillboardPanel` instance for the
+        apply billboard panel.
+
+        :returns: :class:`ApplyBillboardPanel` instance.
+        """
+        return self._create_panel_for_id('applyBillboard')
+
+    @property
+    def check_for_updates(self):
+        """The :class:`CheckForUpdatesPanel` instance for the
+        check for updates panel.
+
+        :returns: :class:`CheckForUpdatesPanel` instance.
+        """
+        return self._create_panel_for_id('checkForUpdates')
+
+    @property
+    def checking_for_updates(self):
+        """The :class:`CheckingForUpdatesPanel` instance for the
+        checking for updates panel.
+
+        :returns: :class:`CheckingForUpdatesPanel` instance.
+        """
+        return self._create_panel_for_id('checkingForUpdates')
+
+    @property
+    def download_and_install(self):
+        """The :class:`DownloadAndInstallPanel` instance for the
+        download and install panel.
+
+        :returns: :class:`DownloadAndInstallPanel` instance.
+        """
+        return self._create_panel_for_id('downloadAndInstall')
+
+    @property
+    def download_failed(self):
+        """The :class:`DownloadFailedPanel` instance for the
+        download failed panel.
+
+        :returns: :class:`DownloadFailedPanel` instance.
+        """
+        return self._create_panel_for_id('downloadFailed')
+
+    @property
+    def downloading(self):
+        """The :class:`DownloadingPanel` instance for the
+        downloading panel.
+
+        :returns: :class:`DownloadingPanel` instance.
+        """
+        return self._create_panel_for_id('downloading')
+
+    @property
+    def panels(self):
+        """List of all the :class:`Panel` instances of the current deck.
+
+        :returns: List of :class:`Panel` instances.
+        """
+        panels = self.marionette.execute_script("""
+          let deck = arguments[0];
+          let panels = [];
+
+          for (let index = 0; index < deck.children.length; index++) {
+            panels.push(deck.children[index].id);
+          }
+
+          return panels;
         """, script_args=[self.element])
 
-    def click_check_for_updates_button(self):
-        """Clicks on "Check for Updates" button."""
-        self._click_deck_button('checkForUpdatesButton')
+        return [self._create_panel_for_id(panel) for panel in panels]
 
-    def click_update_button(self):
-        """Clicks on "Update" button."""
-        self._click_deck_button('updateButton')
+    @property
+    def selected_index(self):
+        """The index of the currently selected panel.
 
-    def click_download_button(self):
-        """Clicks on "Download" button."""
-        self._click_deck_button('downloadAndInstallButton')
+        :return: Index of the selected panel.
+        """
+        return int(self.element.get_attribute('selectedIndex'))
+
+    @property
+    def selected_panel(self):
+        """A :class:`Panel` instance of the currently selected panel.
+
+        :returns: :class:`Panel` instance.
+        """
+        return self.panels[self.selected_index]
+
+
+class Panel(UIBaseLib):
+
+    def __eq__(self, other):
+        return self.element.get_attribute('id') == other.element.get_attribute('id')
+
+
+class ApplyBillboardPanel(Panel):
+
+    @property
+    def apply_billboard_button(self):
+        """The DOM element which represents the Apply Billboard button.
+
+        :returns: Reference to the textbox element.
+        """
+        return self.element.find_element(By.ID, 'applyButtonBillboard')
+
+
+class ApplyPanel(Panel):
+
+    @property
+    def update_button(self):
+        """The DOM element which represents the Update button.
+
+        :returns: Reference to the textbox element.
+        """
+        return self.element.find_element(By.ID, 'updateButton')
+
+
+class CheckForUpdatesPanel(Panel):
+
+    @property
+    def check_for_updates_button(self):
+        """The DOM element which represents the Check for Updates button.
+
+        :returns: Reference to the textbox element.
+        """
+        return self.element.find_element(By.ID, 'checkForUpdatesButton')
+
+
+class CheckingForUpdatesPanel(Panel):
+    pass
+
+
+class DownloadAndInstallPanel(Panel):
+
+    @property
+    def download_button(self):
+        """The DOM element which represents the Download button.
+
+        :returns: Reference to the textbox element.
+        """
+        return self.element.find_element(By.ID, 'downloadAndInstallButton')
+
+
+class DownloadFailedPanel(Panel):
+    pass
+
+
+class DownloadingPanel(Panel):
+    pass

--- a/firefox_puppeteer/ui/about_window/deck.py
+++ b/firefox_puppeteer/ui/about_window/deck.py
@@ -1,0 +1,33 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from marionette_driver import By
+
+from ...base import UIBaseLib
+
+
+class Deck(UIBaseLib):
+
+    def _click_deck_button(self, element_id):
+        button = self.marionette.find_element(By.ID, element_id)
+        button.click()
+
+    @property
+    def wizard_state(self):
+        """ Returns the current state of the update wizard."""
+        return self.marionette.execute_script("""
+          return arguments[0].selectedPanel.id;
+        """, script_args=[self.element])
+
+    def click_check_for_updates_button(self):
+        """Clicks on "Check for Updates" button."""
+        self._click_deck_button('checkForUpdatesButton')
+
+    def click_update_button(self):
+        """Clicks on "Update" button."""
+        self._click_deck_button('updateButton')
+
+    def click_download_button(self):
+        """Clicks on "Download" button."""
+        self._click_deck_button('downloadAndInstallButton')

--- a/firefox_puppeteer/ui/about_window/window.py
+++ b/firefox_puppeteer/ui/about_window/window.py
@@ -63,7 +63,7 @@ class AboutWindow(BaseWindow):
         default to 360 seconds
         """
         assert self.software_update.update_channel.default_channel == \
-               self.software_update.update_channel.channel, \
+            self.software_update.update_channel.channel, \
             'The update channel has been set correctly. ' \
             'default_channel: is {}, while channel is: {}'.format(
                 self.software_update.update_channel.default_channel,

--- a/firefox_puppeteer/ui/windows.py
+++ b/firefox_puppeteer/ui/windows.py
@@ -101,7 +101,7 @@ class Windows(BaseLib):
             from .pageinfo.window import PageInfoWindow
             window = PageInfoWindow(lambda: self.marionette, handle)
         elif window_type == 'Browser:About':
-            from .about_window import AboutWindow
+            from .about_window.window import AboutWindow
             window = AboutWindow(lambda: self.marionette, handle)
         else:
             raise errors.UnknownWindowError('Unknown window type "%s" for handle: "%s"' %
@@ -527,7 +527,7 @@ class BrowserWindow(BaseWindow):
             else:
                 raise ValueError('Unknown opening method: "%s"' % trigger)
 
-        from .about_window import AboutWindow
+        from .about_window.window import AboutWindow
         return BaseWindow.open_window(self, callback, AboutWindow)
 
     def open_page_info_window(self, trigger='menu'):

--- a/firefox_puppeteer/ui/windows.py
+++ b/firefox_puppeteer/ui/windows.py
@@ -95,14 +95,14 @@ class Windows(BaseLib):
             if handle != current_handle:
                 self.marionette.switch_to_window(current_handle)
 
-        if window_type == 'navigator:browser':
+        if window_type == 'Browser:About':
+            from .about_window.window import AboutWindow
+            window = AboutWindow(lambda: self.marionette, handle)
+        elif window_type == 'navigator:browser':
             window = BrowserWindow(lambda: self.marionette, handle)
         elif window_type == 'Browser:page-info':
             from .pageinfo.window import PageInfoWindow
             window = PageInfoWindow(lambda: self.marionette, handle)
-        elif window_type == 'Browser:About':
-            from .about_window.window import AboutWindow
-            window = AboutWindow(lambda: self.marionette, handle)
         else:
             raise errors.UnknownWindowError('Unknown window type "%s" for handle: "%s"' %
                                             (window_type, handle))

--- a/firefox_puppeteer/ui/windows.py
+++ b/firefox_puppeteer/ui/windows.py
@@ -100,6 +100,9 @@ class Windows(BaseLib):
         elif window_type == 'Browser:page-info':
             from .pageinfo.window import PageInfoWindow
             window = PageInfoWindow(lambda: self.marionette, handle)
+        elif window_type == 'Browser:About':
+            from .about_window import AboutWindow
+            window = AboutWindow(lambda: self.marionette, handle)
         else:
             raise errors.UnknownWindowError('Unknown window type "%s" for handle: "%s"' %
                                             (window_type, handle))
@@ -503,6 +506,29 @@ class BrowserWindow(BaseWindow):
                 raise ValueError('Unknown opening method: "%s"' % trigger)
 
         return BaseWindow.open_window(self, callback, BrowserWindow)
+
+    def open_about_window(self, trigger='menu'):
+        """Opens the about window by using the specified trigger.
+
+        :param trigger: Optional, method in how to open the new browser window. This can
+         either the string `menu` or a callback which gets triggered
+         with the current :class:`BrowserWindow` as parameter. Defaults to `menu`.
+
+        :returns: :class:`AboutWindow` instance of the opened window.
+        """
+        def callback(win):
+            # Prepare action which triggers the opening of the browser window
+            if callable(trigger):
+                trigger(win)
+            elif trigger == 'menu':
+                # TODO: Make use of menubar class once it supports ids
+                menu = win.marionette.find_element(By.ID, 'aboutName')
+                menu.click()
+            else:
+                raise ValueError('Unknown opening method: "%s"' % trigger)
+
+        from .about_window import AboutWindow
+        return BaseWindow.open_window(self, callback, AboutWindow)
 
     def open_page_info_window(self, trigger='menu'):
         """Opens the page info window by using the specified trigger.


### PR DESCRIPTION
This includes the current commits from PR #90 as `AboutWindow` depends on `SoftwareUpdate`. All of the changes for `AboutWindow` are included in a single commit.