### PR TITLE
Bug 1142303 - Run safe browsing tests in new tab to ensure notification bar close

### DIFF
--- a/firefox_ui_tests/remote/security/test_safe_browsing_notification.py
+++ b/firefox_ui_tests/remote/security/test_safe_browsing_notification.py
@@ -37,6 +37,10 @@ class TestSafeBrowsingNotificationBar(FirefoxTestCase):
         # hg.mozilla.org/mozilla-central/file/46aebcd9481e/browser/base/content/browser.js#l1194
         time.sleep(3)
 
+        # TODO: Bug 1139544: While we don't have a reliable way to close the safe browsing
+        # notification bar when a test fails, run this test in a new tab.
+        self.browser.tabbar.open_tab()
+
     def tearDown(self):
         try:
             self.utils.remove_perms('www.itisatrap.org', 'safe-browsing')

--- a/firefox_ui_tests/remote/security/test_safe_browsing_warning_pages.py
+++ b/firefox_ui_tests/remote/security/test_safe_browsing_warning_pages.py
@@ -29,9 +29,14 @@ class TestSafeBrowsingWarningPages(FirefoxTestCase):
         # hg.mozilla.org/mozilla-central/file/46aebcd9481e/browser/base/content/browser.js#l1194
         time.sleep(3)
 
+        # TODO: Bug 1139544: While we don't have a reliable way to close the safe browsing
+        # notification bar when a test fails, run this test in a new tab.
+        self.browser.tabbar.open_tab()
+
     def tearDown(self):
         try:
             self.utils.remove_perms('www.itisatrap.org', 'safe-browsing')
+            self.browser.tabbar.close_all_tabs([self.browser.tabbar.tabs[0]])
         finally:
             FirefoxTestCase.tearDown(self)
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1142303