### PR TITLE
Bug 1132624 - Convert Mozmill testEnablePrivilege

### DIFF
--- a/firefox_ui_tests/functional/security/test_enable_privilege.py
+++ b/firefox_ui_tests/functional/security/test_enable_privilege.py
@@ -1,0 +1,25 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from marionette_driver import By
+
+from firefox_ui_harness.testcase import FirefoxTestCase
+
+
+class TestEnablePrivilege(FirefoxTestCase):
+
+    def setUp(self):
+        FirefoxTestCase.setUp(self)
+
+        self.url = self.marionette.absolute_url('security/enable_privilege.html')
+
+        #self.prefs.set_pref(
+        #    'security.turn_off_all_security_so_that_viruses_can_take_over_this_computer', False)
+
+    def test_enable_privilege(self):
+        with self.marionette.using_context('content'):
+            self.marionette.navigate(self.url)
+
+            result = self.marionette.find_element(By.ID, 'result')
+            self.assertEqual(result.get_attribute('textContent'), 'PASS')

--- a/firefox_ui_tests/resources/security/enable_privilege.html
+++ b/firefox_ui_tests/resources/security/enable_privilege.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+  <head>
+    <title>Test page for enablePrivilege</title>
+    <script>
+      function init() {
+        var result = document.getElementById("result");
+        try {
+          netscape.security.PrivilegeManager.enablePrivilege("UniversalXPConnect");
+          result.textContent = "FAIL";
+        }
+        catch (ex) {
+          result.textContent = "PASS";
+        }
+      }
+    </script>
+  </head>
+  <body onload="init();">
+    <p id="result"></p>
+  </body>
+</html>


### PR DESCRIPTION
This short test conversion is blocked for the moment by security preference settings. There's more information in the IRC logs for today, March 19th, for both #ateam and #automation. 

I've pushed up my WIP here in case the block takes long to resolve.

https://bugzilla.mozilla.org/show_bug.cgi?id=1132624