### PR TITLE
Bug 1132701 - Convert Mozmill testSSLStatusAfterRestart

### DIFF
--- a/firefox_ui_harness/runners/base.py
+++ b/firefox_ui_harness/runners/base.py
@@ -24,7 +24,7 @@ DEFAULT_PREFS = {
     'browser.search.update': False,
     'browser.sessionstore.resume_from_crash': False,
     'browser.shell.checkDefaultBrowser': False,
-    'browser.startup.page': 0,
+    'browser.startup.page': 3,
     'browser.tabs.animate': False,
     'browser.tabs.warnOnClose': False,
     'browser.tabs.warnOnOpen': False,

--- a/firefox_ui_harness/runners/base.py
+++ b/firefox_ui_harness/runners/base.py
@@ -24,7 +24,7 @@ DEFAULT_PREFS = {
     'browser.search.update': False,
     'browser.sessionstore.resume_from_crash': False,
     'browser.shell.checkDefaultBrowser': False,
-    'browser.startup.page': 3,
+    'browser.startup.page': 0,
     'browser.tabs.animate': False,
     'browser.tabs.warnOnClose': False,
     'browser.tabs.warnOnOpen': False,

--- a/firefox_ui_harness/testcase.py
+++ b/firefox_ui_harness/testcase.py
@@ -22,6 +22,14 @@ class FirefoxTestCase(MarionetteTestCase, Puppeteer):
 
         :param flags: Specific restart flags for Firefox
         """
+        # TODO: Bug 1148220 Marionette's in_app restart has to send 'quit-application-requested'
+        # observer notification before an in_app restart
+        self.marionette.execute_script("""
+          Components.utils.import("resource://gre/modules/Services.jsm");
+          let cancelQuit = Components.classes["@mozilla.org/supports-PRBool;1"]
+                                     .createInstance(Components.interfaces.nsISupportsPRBool);
+          Services.obs.notifyObservers(cancelQuit, "quit-application-requested", null);
+        """)
         self.marionette.restart(in_app=True)
 
         # Marionette doesn't keep the former context, so restore to chrome

--- a/firefox_ui_tests/remote/security/manifest.ini
+++ b/firefox_ui_tests/remote/security/manifest.ini
@@ -5,5 +5,6 @@
 [test_safe_browsing_warning_pages.py]
 [test_security_notification.py]
 [test_ssl_disabled_error_page.py]
+[test_ssl_status_after_restart.py]
 [test_submit_unencrypted_info_warning.py]
 [test_unknown_issuer.py]

--- a/firefox_ui_tests/remote/security/test_ssl_status_after_restart.py
+++ b/firefox_ui_tests/remote/security/test_ssl_status_after_restart.py
@@ -40,6 +40,7 @@ class TestSSLStatusAfterRestart(FirefoxTestCase):
         try:
             self.windows.close_all([self.browser])
             self.browser.tabbar.close_all_tabs([self.browser.tabbar.tabs[0]])
+            self.browser.switch_to()
             self.identity_popup.close(force=True)
         finally:
             FirefoxTestCase.tearDown(self)
@@ -116,3 +117,4 @@ class TestSSLStatusAfterRestart(FirefoxTestCase):
         self.assertEqual(page_info.deck.security.verifier.get_attribute('value'),
                          cert['issuerOrganization'],
                          'Verifier matches issuer of certificate for ' + url)
+        page_info.close()

--- a/firefox_ui_tests/remote/security/test_ssl_status_after_restart.py
+++ b/firefox_ui_tests/remote/security/test_ssl_status_after_restart.py
@@ -1,0 +1,123 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from marionette_driver import Wait
+from marionette_driver.errors import NoSuchElementException
+
+from firefox_ui_harness.decorators import skip_if_e10s, skip_under_xvfb
+from firefox_ui_harness.testcase import FirefoxTestCase
+
+
+class TestSSLStatusAfterRestart(FirefoxTestCase):
+
+    def setUp(self):
+        FirefoxTestCase.setUp(self)
+
+        self.test_data = [
+            {
+                'url': 'https://ssl-dv.mozqa.com',
+                'identity': '',
+                'type': 'verifiedDomain'
+            },
+            {
+                'url': 'https://ssl-ev.mozqa.com/',
+                'identity': 'Mozilla Corporation',
+                'type': 'verifiedIdentity'
+            },
+            {
+                'url': 'https://ssl-ov.mozqa.com/',
+                'identity': '',
+                'type': 'verifiedDomain'
+            }
+        ]
+
+        # Set browser to restore previous session
+        self.prefs.set_pref('browser.startup.page', 3)
+
+        self.identity_popup = self.browser.navbar.locationbar.identity_popup
+
+    def tearDown(self):
+        try:
+            self.identity_popup.close(force=True)
+            self.browser.tabbar.close_all_tabs([self.browser.tabbar.tabs[0]])
+        except NoSuchElementException:
+            # TODO: A NoSuchElementException may be thrown here when the test is skipped
+            # as under xvfb.
+            pass
+        finally:
+            FirefoxTestCase.tearDown(self)
+
+    @skip_if_e10s
+    @skip_under_xvfb
+    # Bug 995801: Test certificate status after browser restart
+    def test_ssl_status_after_restart(self):
+        for item in self.test_data:
+            with self.marionette.using_context('content'):
+                self.marionette.navigate(item['url'])
+            self.verify_certificate_status(item)
+            self.browser.tabbar.open_tab()
+
+        '''
+        self.restart()
+
+        i = 0
+        for item in self.test_data:
+            self.browser.tabbar.switch_to(i)
+            self.verify_certificate_status(item)
+            i = i + 1
+        '''
+
+    def verify_certificate_status(self, item):
+        url = item['url']
+
+        # Check the favicon
+        # TODO: find a better way to check, e.g., mozmill's isDisplayed
+        self.assertEqual(self.browser.navbar.locationbar.favicon.get_attribute('hidden'), 'false',
+                         'Lock icon is visible in identity box for ' + url)
+
+        self.identity_popup.box.click()
+        Wait(self.marionette).until(lambda _: self.identity_popup.is_open)
+
+        # Check the type shown on the idenity popup doorhanger
+        self.assertEqual(self.identity_popup.popup.get_attribute('className'),
+                         item['type'],
+                         'Extended certificate is verified for ' + url)
+
+        # Check the identity label
+        self.assertEqual(self.identity_popup.organization_label.get_attribute('value'),
+                         item['identity'],
+                         'Identity name is correct for ' + url)
+
+        # Get the information from the certificate
+        cert = self.browser.tabbar.selected_tab.certificate
+
+        # Open the Page Info window by clicking the More Information button
+        page_info = self.browser.open_page_info_window(
+            lambda _: self.identity_popup.more_info_button.click())
+
+        if item['identity'] != '':
+            owner = cert['organization']
+        else:
+            owner = page_info.get_property('securityNoOwner')
+
+        try:
+            # Verify that the current panel is the security panel
+            self.assertEqual(page_info.deck.selected_panel, page_info.deck.security)
+
+            # Verify the domain listed on the security panel
+            self.assertIn(self.security.get_domain_from_common_name(cert['commonName']),
+                          page_info.deck.security.domain.get_attribute('value'),
+                          'Expected domain found in certificate for ' + url)
+
+            # Verify the owner listed on the security panel
+            self.assertEqual(page_info.deck.security.owner.get_attribute('value'), owner,
+                             'Expected owner label found for ' + url)
+
+            # Verify the verifier listed on the security panel
+            self.assertEqual(page_info.deck.security.verifier.get_attribute('value'),
+                             cert['issuerOrganization'],
+                             'Verifier matches issuer of certificate for ' + url)
+        finally:
+            page_info.close()
+            self.browser.focus()

--- a/firefox_ui_tests/remote/security/test_ssl_status_after_restart.py
+++ b/firefox_ui_tests/remote/security/test_ssl_status_after_restart.py
@@ -53,13 +53,6 @@ class TestSSLStatusAfterRestart(FirefoxTestCase):
             self.verify_certificate_status(item)
             self.browser.tabbar.open_tab()
 
-        # TODO: Bug 1148220 add ability to store open tabs to restart method
-        self.marionette.execute_script("""
-          Components.utils.import("resource://gre/modules/Services.jsm");
-          let cancelQuit = Components.classes["@mozilla.org/supports-PRBool;1"]
-                                     .createInstance(Components.interfaces.nsISupportsPRBool);
-          Services.obs.notifyObservers(cancelQuit, "quit-application-requested", null);
-        """)
         self.restart()
 
         for index, item in enumerate(self.test_data):
@@ -101,7 +94,7 @@ class TestSSLStatusAfterRestart(FirefoxTestCase):
 
         # Verify the domain listed on the security panel
         # If this is a wildcard cert, check only the domain
-        if '*' == cert['commonName'][0]:
+        if cert['commonName'].startswith('*'):
             self.assertIn(self.security.get_domain_from_common_name(cert['commonName']),
                           page_info.deck.security.domain.get_attribute('value'),
                           'Expected domain found in certificate for ' + url)

--- a/firefox_ui_tests/remote/security/test_ssl_status_after_restart.py
+++ b/firefox_ui_tests/remote/security/test_ssl_status_after_restart.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from marionette_driver import Wait
-from marionette_driver.errors import NoSuchElementException
 
 from firefox_ui_harness.decorators import skip_if_e10s, skip_under_xvfb
 from firefox_ui_harness.testcase import FirefoxTestCase
@@ -41,10 +40,6 @@ class TestSSLStatusAfterRestart(FirefoxTestCase):
         try:
             self.browser.tabbar.close_all_tabs([self.browser.tabbar.tabs[0]])
             self.identity_popup.close(force=True)
-        except NoSuchElementException:
-            # TODO: A NoSuchElementException may be thrown here when the test is skipped
-            # as under xvfb.
-            pass
         finally:
             FirefoxTestCase.tearDown(self)
 
@@ -58,6 +53,13 @@ class TestSSLStatusAfterRestart(FirefoxTestCase):
             new_tab = self.browser.tabbar.open_tab()
             new_tab.select()
 
+        # TODO: Bug 1148220 add ability to store open tabs to restart method
+        self.marionette.execute_script("""
+          Components.utils.import("resource://gre/modules/Services.jsm");
+          let cancelQuit = Components.classes["@mozilla.org/supports-PRBool;1"]
+                                     .createInstance(Components.interfaces.nsISupportsPRBool);
+          Services.obs.notifyObservers(cancelQuit, "quit-application-requested", null);
+        """)
         self.restart()
 
         i = 0


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1132701

It looks like this test should use the restart method added in PR #122. Until that lands, I've commented out that part of the code to let Travis test the rest.

The Mozmill test defines three separate but nearly identical helper methods to handle the page info window for each test item. I've combined them here, adding the item's url to each assertion's message. I wonder if I've missed some reason for separating these as the Mozmill test does.