### PR TITLE
Bug 1149818 - Set the homepage_override_url to 'about:blank' so we don't...

### DIFF
--- a/firefox_ui_harness/runners/update.py
+++ b/firefox_ui_harness/runners/update.py
@@ -17,6 +17,7 @@ import firefox_ui_tests
 
 DEFAULT_PREFS = {
     'app.update.log': True,
+    'startup.homepage_override_url': 'about:blank',
 }
 
 


### PR DESCRIPTION
... leak a tab when updating across verion numbers.;r=ahal