### PR TITLE
Bug 1132708 - Convert testUntrustedConnection

### DIFF
--- a/firefox_ui_tests/remote/security/manifest.ini
+++ b/firefox_ui_tests/remote/security/manifest.ini
@@ -8,3 +8,4 @@
 [test_ssl_status_after_restart.py]
 [test_submit_unencrypted_info_warning.py]
 [test_unknown_issuer.py]
+[test_untrusted_connection_error_page.py]

--- a/firefox_ui_tests/remote/security/test_untrusted_connection_error_page.py
+++ b/firefox_ui_tests/remote/security/test_untrusted_connection_error_page.py
@@ -1,0 +1,32 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import time
+
+from marionette_driver import By, Wait
+from marionette_driver.errors import MarionetteException
+
+from firefox_ui_harness.testcase import FirefoxTestCase
+
+
+class TestUntrustedConnectionErrorPage(FirefoxTestCase):
+    def setUp(self):
+        FirefoxTestCase.setUp(self)
+
+        self.url = 'https://ssl-selfsigned.mozqa.com'
+
+    def test_untrusted_connection_error_page(self):
+        self.marionette.set_context('content')
+
+        # In some localized builds, the default page redirects
+        target_url = self.browser.get_final_url(self.browser.default_homepage)
+
+        self.assertRaises(MarionetteException, self.marionette.navigate, self.url)
+
+        # Wait for the DOM to receive events
+        time.sleep(1)
+
+        button = self.marionette.find_element(By.ID, "getMeOutOfHereButton")
+        button.click()
+        Wait(self.marionette).until(lambda mn: target_url == self.marionette.get_url())


### PR DESCRIPTION
Just trying to finish this up before the end of the month, this replaces PR #133, which replaced PR #89. 
Thanks @Ethcelon and @jmaher!
The current PR simply removes the edits to test_security_notification present in 133.

https://bugzilla.mozilla.org/show_bug.cgi?id=1132708