### PR TITLE
Bug 1156475 - Avoid global timeout for update tests that fail when the a...

### DIFF
--- a/firefox_ui_tests/update/direct/test_direct_update.py
+++ b/firefox_ui_tests/update/direct/test_direct_update.py
@@ -16,7 +16,16 @@ class TestDirectUpdate(UpdateTestCase):
         finally:
             UpdateTestCase.tearDown(self)
 
-    def test_update(self):
+    def _test_update(self):
         self.download_and_apply_available_update(force_fallback=False)
 
         self.check_update_applied()
+
+    def test_update(self):
+        try:
+            self._test_update()
+        except:
+            # Switch context to the main browser window before embarking
+            # down the failure code path to work around bug 1141519.
+            self.browser.switch_to()
+            raise

--- a/firefox_ui_tests/update/fallback/test_fallback_update.py
+++ b/firefox_ui_tests/update/fallback/test_fallback_update.py
@@ -16,9 +16,18 @@ class TestFallbackUpdate(UpdateTestCase):
         finally:
             UpdateTestCase.tearDown(self)
 
-    def test_update(self):
+    def _test_update(self):
         self.download_and_apply_available_update(force_fallback=True)
 
         self.download_and_apply_forced_update()
 
         self.check_update_applied()
+
+    def test_update(self):
+        try:
+            self._test_update()
+        except:
+            # Switch context to the main browser window before embarking
+            # down the failure code path to work around bug 1141519.
+            self.browser.switch_to()
+            raise


### PR DESCRIPTION
...bout window is focused by switching back to the main browser window before allowing the failure to propagate.