### PR TITLE
Use mozinstall 1.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ deps = [
     'marionette-driver == 0.4',
     'mozfile == 1.1',
     'mozinfo == 0.7',
-    'mozinstall == 1.11',
+    'mozinstall == 1.12',
     'mozlog == 2.10',
 ]
 


### PR DESCRIPTION
We need 1.12 since it has two fixes:
* Fix for white spaces on path for Mac dmg files
* Use /extractdir for Windows installers.

@chmanchester r?