### PR TITLE
Use newer version of marionette driver

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ PACKAGE_VERSION = '0.2'
 
 deps = [
     'marionette-client == 0.10',
-    'marionette-driver == 0.4',
+    'marionette-driver == 0.5',
     'mozfile == 1.1',
     'mozinfo == 0.7',
     'mozinstall == 1.12',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 PACKAGE_VERSION = '0.2'
 
 deps = [
-    'marionette-client == 0.10',
+    'marionette-client == 0.12',
     'marionette-driver == 0.5',
     'mozfile == 1.1',
     'mozinfo == 0.7',


### PR DESCRIPTION
The newer version passes the right parameters to mozrunner so it does not fill up /tmp.

See bug https://bugzilla.mozilla.org/show_bug.cgi?id=1083131