### PR TITLE
Bug 1168533 - Add @skip_under_xvfb to test (not class)

### DIFF
--- a/firefox_ui_tests/functional/locationbar/manifest.ini
+++ b/firefox_ui_tests/functional/locationbar/manifest.ini
@@ -1,3 +1,3 @@
-[test_suggest_bookmarks.py]
+# [test_access_locationbar.py]
 [test_escape_autocomplete.py]
-[test_access_locationbar.py]
+[test_suggest_bookmarks.py]

--- a/firefox_ui_tests/functional/locationbar/test_access_locationbar.py
+++ b/firefox_ui_tests/functional/locationbar/test_access_locationbar.py
@@ -6,7 +6,6 @@ from firefox_ui_harness.decorators import skip_under_xvfb
 from firefox_ui_harness import FirefoxTestCase
 
 
-@skip_under_xvfb
 class TestAccessLocationBar(FirefoxTestCase):
 
     def setUp(self):
@@ -27,6 +26,7 @@ class TestAccessLocationBar(FirefoxTestCase):
         self.autocomplete_results = self.locationbar.autocomplete_results
         self.urlbar = self.locationbar.urlbar
 
+    @skip_under_xvfb
     def test_access_locationbar_history(self):
 
         # Open some local pages, then about:blank

--- a/firefox_ui_tests/functional/locationbar/test_escape_autocomplete.py
+++ b/firefox_ui_tests/functional/locationbar/test_escape_autocomplete.py
@@ -6,7 +6,6 @@ from firefox_ui_harness.decorators import skip_under_xvfb
 from firefox_ui_harness import FirefoxTestCase
 
 
-@skip_under_xvfb
 class TestEscapeAutocomplete(FirefoxTestCase):
 
     def setUp(self):
@@ -31,6 +30,7 @@ class TestEscapeAutocomplete(FirefoxTestCase):
         self.autocomplete_results.close(force=True)
         FirefoxTestCase.tearDown(self)
 
+    @skip_under_xvfb
     def test_escape_autocomplete(self):
         # Open some local pages
         def load_urls():

--- a/firefox_ui_tests/functional/locationbar/test_suggest_bookmarks.py
+++ b/firefox_ui_tests/functional/locationbar/test_suggest_bookmarks.py
@@ -8,7 +8,6 @@ from firefox_ui_harness.decorators import skip_under_xvfb
 from firefox_ui_harness import FirefoxTestCase
 
 
-@skip_under_xvfb
 class TestStarInAutocomplete(FirefoxTestCase):
     """ This replaces
     http://hg.mozilla.org/qa/mozmill-tests/file/default/firefox/tests/functional/testAwesomeBar/testSuggestBookmarks.js
@@ -38,6 +37,7 @@ class TestStarInAutocomplete(FirefoxTestCase):
         finally:
             FirefoxTestCase.tearDown(self)
 
+    @skip_under_xvfb
     def test_star_in_autocomplete(self):
         search_string = 'grants'
 


### PR DESCRIPTION
This PR includes patches to the tests in functional/locationbar.

It may be helpful to look for other tests silently failing to run with skip decorators applied to the class rather than the test.