### PR TITLE
Bug 1168545 - Add default preference to disable reader view intro

### DIFF
--- a/firefox_ui_harness/runners/base.py
+++ b/firefox_ui_harness/runners/base.py
@@ -19,6 +19,7 @@ DEFAULT_PREFS = {
     # can correctly handle error pages
     'browser.newtab.url': 'about:newtab',
     'browser.newtabpage.enabled': False,
+    'browser.reader.detectedFirstArticle': True,
     'browser.safebrowsing.enabled': False,
     'browser.safebrowsing.malware.enabled': False,
     'browser.search.update': False,


### PR DESCRIPTION
Adding this default preference may still be a good idea, though it doesn't alone enable functional/locationbar/test_access_locationbar to pass.