### PR TITLE
Bug 1170148 - Fix test_toolbars.py for unified auto-complete feature

### DIFF
--- a/firefox_puppeteer/tests/test_toolbars.py
+++ b/firefox_puppeteer/tests/test_toolbars.py
@@ -137,9 +137,6 @@ class TestAutoCompleteResults(FirefoxTestCase):
             all_matches = title_matches + url_matches
             self.assertTrue(len(all_matches) > 0)
             for match_fragment in all_matches:
-                # skip the new unified search item, if present
-                if match_fragment == '- Search with Yahoo':
-                    continue
                 self.assertIn(input_text, match_fragment.lower())
 
 

--- a/firefox_puppeteer/tests/test_toolbars.py
+++ b/firefox_puppeteer/tests/test_toolbars.py
@@ -72,7 +72,6 @@ class TestLocationBar(FirefoxTestCase):
         self.assertEqual('toolbarbutton', stop_button.get_attribute('localName'))
 
 
-@unittest.skip('Bug 1170148 - Fix test_toolbars.py for unified auto-complete feature')
 class TestAutoCompleteResults(FirefoxTestCase):
     def setUp(self):
         FirefoxTestCase.setUp(self)
@@ -97,7 +96,7 @@ class TestAutoCompleteResults(FirefoxTestCase):
         self.assertFalse(autocompleteresults.is_open)
         self.browser.navbar.locationbar.urlbar.send_keys('a')
         results = autocompleteresults.results
-        self.wait_for_condition(lambda _: autocompleteresults.is_open)
+        self.wait_for_condition(lambda _: autocompleteresults.is_complete)
         visible_result_count = len(autocompleteresults.visible_results)
         self.assertTrue(visible_result_count > 0)
         self.assertEqual(visible_result_count,
@@ -107,7 +106,7 @@ class TestAutoCompleteResults(FirefoxTestCase):
     def test_close(self):
         autocompleteresults = self.browser.navbar.locationbar.autocomplete_results
         self.browser.navbar.locationbar.urlbar.send_keys('a')
-        self.wait_for_condition(lambda _: autocompleteresults.is_open)
+        self.wait_for_condition(lambda _: autocompleteresults.is_complete)
         # The Wait in the library implementation will fail this if this doesn't
         # end up closing.
         autocompleteresults.close()
@@ -116,7 +115,7 @@ class TestAutoCompleteResults(FirefoxTestCase):
     def test_force_close(self):
         autocompleteresults = self.browser.navbar.locationbar.autocomplete_results
         self.browser.navbar.locationbar.urlbar.send_keys('a')
-        self.wait_for_condition(lambda _: autocompleteresults.is_open)
+        self.wait_for_condition(lambda _: autocompleteresults.is_complete)
         # The Wait in the library implementation will fail this if this doesn't
         # end up closing.
         autocompleteresults.close(force=True)
@@ -129,7 +128,7 @@ class TestAutoCompleteResults(FirefoxTestCase):
 
         autocompleteresults = self.browser.navbar.locationbar.autocomplete_results
         self.browser.navbar.locationbar.urlbar.send_keys(input_text)
-        self.wait_for_condition(lambda _: autocompleteresults.is_open)
+        self.wait_for_condition(lambda _: autocompleteresults.is_complete)
         visible_results = autocompleteresults.visible_results
         self.assertTrue(len(visible_results) > 0)
         for result in visible_results:

--- a/firefox_puppeteer/tests/test_toolbars.py
+++ b/firefox_puppeteer/tests/test_toolbars.py
@@ -137,7 +137,10 @@ class TestAutoCompleteResults(FirefoxTestCase):
             all_matches = title_matches + url_matches
             self.assertTrue(len(all_matches) > 0)
             for match_fragment in all_matches:
-                self.assertIn(match_fragment, (input_text, input_text.upper()))
+                # skip the new unified search item, if present
+                if match_fragment == '- Search with Yahoo':
+                    continue
+                self.assertIn(input_text, match_fragment.lower())
 
 
 class TestIdentityPopup(FirefoxTestCase):

--- a/firefox_puppeteer/tests/test_toolbars.py
+++ b/firefox_puppeteer/tests/test_toolbars.py
@@ -136,7 +136,8 @@ class TestAutoCompleteResults(FirefoxTestCase):
             url_matches = autocompleteresults.get_matching_text(result, "url")
             all_matches = title_matches + url_matches
             self.assertTrue(len(all_matches) > 0)
-            for match_fragment in all_matches:
+            # check all but the last item (the new unified search item from Bug 1168811)
+            for match_fragment in all_matches[:-1]:
                 self.assertIn(input_text, match_fragment.lower())
 
 

--- a/firefox_puppeteer/tests/test_toolbars.py
+++ b/firefox_puppeteer/tests/test_toolbars.py
@@ -132,12 +132,14 @@ class TestAutoCompleteResults(FirefoxTestCase):
         visible_results = autocompleteresults.visible_results
         self.assertTrue(len(visible_results) > 0)
         for result in visible_results:
+            # check matching text only for results of type bookmark
+            if result.get_attribute('type') != 'bookmark':
+                continue
             title_matches = autocompleteresults.get_matching_text(result, "title")
             url_matches = autocompleteresults.get_matching_text(result, "url")
             all_matches = title_matches + url_matches
             self.assertTrue(len(all_matches) > 0)
-            # check all but the last item (the new unified search item from Bug 1168811)
-            for match_fragment in all_matches[:-1]:
+            for match_fragment in all_matches:
                 self.assertIn(input_text, match_fragment.lower())
 
 

--- a/firefox_puppeteer/tests/test_toolbars.py
+++ b/firefox_puppeteer/tests/test_toolbars.py
@@ -106,7 +106,7 @@ class TestAutoCompleteResults(FirefoxTestCase):
     def test_close(self):
         autocompleteresults = self.browser.navbar.locationbar.autocomplete_results
         self.browser.navbar.locationbar.urlbar.send_keys('a')
-        self.wait_for_condition(lambda _: autocompleteresults.is_complete)
+        self.wait_for_condition(lambda _: autocompleteresults.is_open)
         # The Wait in the library implementation will fail this if this doesn't
         # end up closing.
         autocompleteresults.close()
@@ -115,7 +115,7 @@ class TestAutoCompleteResults(FirefoxTestCase):
     def test_force_close(self):
         autocompleteresults = self.browser.navbar.locationbar.autocomplete_results
         self.browser.navbar.locationbar.urlbar.send_keys('a')
-        self.wait_for_condition(lambda _: autocompleteresults.is_complete)
+        self.wait_for_condition(lambda _: autocompleteresults.is_open)
         # The Wait in the library implementation will fail this if this doesn't
         # end up closing.
         autocompleteresults.close(force=True)

--- a/firefox_puppeteer/ui/toolbars.py
+++ b/firefox_puppeteer/ui/toolbars.py
@@ -315,6 +315,22 @@ class AutocompleteResults(BaseLib):
         return self.popup.get_attribute('state') == 'open'
 
     @property
+    def is_complete(self):
+        """Returns when this popup is open and search results are complete.
+
+        :returns: True when the popup is open including any search results, otherwise false.
+        """
+        return self.marionette.execute_script("""
+          Components.utils.import("resource://gre/modules/Services.jsm");
+          let win = Services.focus.activeWindow;
+          if (win) {
+            return win.gURLBar.controller.searchStatus >=
+                   Ci.nsIAutoCompleteController.STATUS_COMPLETE_NO_MATCH;
+          }
+          return null;
+        """)
+
+    @property
     def popup(self):
         """Provides access to the popup result element.
 

--- a/firefox_puppeteer/ui/toolbars.py
+++ b/firefox_puppeteer/ui/toolbars.py
@@ -316,9 +316,9 @@ class AutocompleteResults(BaseLib):
 
     @property
     def is_complete(self):
-        """Returns when this popup is open and search results are complete.
+        """Returns when this popup is open and autocomplete results are complete.
 
-        :returns: True when the popup is open including any search results, otherwise false.
+        :returns: True, when autocomplete results have been populated.
         """
         return self.marionette.execute_script("""
           Components.utils.import("resource://gre/modules/Services.jsm");


### PR DESCRIPTION
This patch adds the property is_complete to the autocomplete results class and replaces ...is_open with ...is_complete in problem tests in test_toolbars.py.

Perhaps it would be better to replace the code in the ...is_open property with code similar to that in ...is_complete, and skip adding a separate property?

https://bugzilla.mozilla.org/show_bug.cgi?id=1170148