### PR TITLE
Bug 1180429 - Missing headers for classes in TOC of docs

### DIFF
--- a/firefox_puppeteer/docs/api/appinfo.rst
+++ b/firefox_puppeteer/docs/api/appinfo.rst
@@ -8,8 +8,8 @@ Firefox and provides access to a subset of its members.
 
 .. _nsIXULAppInfo: https://developer.mozilla.org/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIXULAppInfo
 
-API reference
--------------
+AppInfo
+-------
 
 .. autoclass:: AppInfo
    :members:

--- a/firefox_puppeteer/docs/api/keys.rst
+++ b/firefox_puppeteer/docs/api/keys.rst
@@ -3,6 +3,9 @@
 Keys
 ====
 
+Keys
+----
+
 .. autoclass:: Keys
    :members:
    :inherited-members:

--- a/firefox_puppeteer/docs/api/l10n.rst
+++ b/firefox_puppeteer/docs/api/l10n.rst
@@ -3,6 +3,9 @@
 Localization
 ============
 
+Localization
+------------
+
 .. autoclass:: L10n
    :members:
    :undoc-members:

--- a/firefox_puppeteer/docs/api/places.rst
+++ b/firefox_puppeteer/docs/api/places.rst
@@ -3,11 +3,11 @@
 Places
 ======
 
-The Places class provides low-level access for seveal boomarks and history
+The Places class provides low-level access for several bookmark and history
 related methods.
 
-API reference
--------------
+Places
+------
 
 .. autoclass:: Places
    :members:

--- a/firefox_puppeteer/docs/api/prefs.rst
+++ b/firefox_puppeteer/docs/api/prefs.rst
@@ -11,8 +11,8 @@ preferences.
 
 .. _nsIPrefBranch: https://developer.mozilla.org/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIPrefBranch
 
-API reference
--------------
+Preferences
+-----------
 
 .. autoclass:: Preferences
    :members:

--- a/firefox_puppeteer/docs/api/security.rst
+++ b/firefox_puppeteer/docs/api/security.rst
@@ -6,8 +6,8 @@ Security
 The Security class gives access to various helper methods, which assist in working with
 certificates or accessing specific security related information.
 
-API reference
--------------
+Security
+--------
 
 .. autoclass:: Security
    :members:

--- a/firefox_puppeteer/docs/api/software_update.rst
+++ b/firefox_puppeteer/docs/api/software_update.rst
@@ -5,6 +5,9 @@ SoftwareUpdate
 
 The SoftwareUpdate class provides helpers for update tests.
 
+SoftwareUpdate
+--------------
+
 .. autoclass:: SoftwareUpdate
    :members:
 

--- a/firefox_puppeteer/docs/api/utils.rst
+++ b/firefox_puppeteer/docs/api/utils.rst
@@ -5,8 +5,8 @@ Utils
 
 The Utils class gives access to various helper methods.
 
-API reference
--------------
+Utils
+-----
 
 .. autoclass:: Utils
    :members:

--- a/firefox_puppeteer/docs/ui/tabbar.rst
+++ b/firefox_puppeteer/docs/ui/tabbar.rst
@@ -1,7 +1,10 @@
-  .. py:currentmodule:: firefox_puppeteer.ui.tabbar
+.. py:currentmodule:: firefox_puppeteer.ui.tabbar
 
 Tabbar
 ======
+
+TabBar
+------
 
 .. autoclass:: TabBar
    :members:
@@ -12,7 +15,7 @@ Tab
 .. autoclass:: Tab
    :members:
 
-Menu Panel
+MenuPanel
 ----------
 
 .. autoclass:: MenuPanel

--- a/firefox_puppeteer/docs/ui/toolbars.rst
+++ b/firefox_puppeteer/docs/ui/toolbars.rst
@@ -1,16 +1,28 @@
 .. py:currentmodule:: firefox_puppeteer.ui.toolbars
 
 Toolbars
---------
+========
+
+NavBar
+------
 
 .. autoclass:: NavBar
    :members:
 
+LocationBar
+-----------
+
 .. autoclass:: LocationBar
    :members:
 
+AutocompleteResults
+-------------------
+
 .. autoclass:: AutocompleteResults
    :members:
+
+IdentityPopup
+-------------
 
 .. autoclass:: IdentityPopup
    :members:

--- a/firefox_puppeteer/docs/ui/windows.rst
+++ b/firefox_puppeteer/docs/ui/windows.rst
@@ -3,11 +3,20 @@
 Windows
 =======
 
+Windows
+-------
+
 .. autoclass:: Windows
    :members:
 
+BaseWindow
+----------
+
 .. autoclass:: BaseWindow
    :members:
+
+BrowserWindow
+-------------
 
 .. autoclass:: BrowserWindow
    :members:


### PR DESCRIPTION
Hi, @whimboo, this changes files in the docs/ui directory so that all classes are listed in the TOC (under the library containing them). If you like this, I could do the same for the docs/api directory. 