### PR TITLE
Bug 1181788 - Use uri objects instead of strings in utils.remove_perm…

### DIFF
--- a/firefox_puppeteer/api/utils.py
+++ b/firefox_puppeteer/api/utils.py
@@ -23,7 +23,8 @@ class Utils(BaseLib):
         with self.marionette.using_context('chrome'):
             self.marionette.execute_script("""
               Components.utils.import("resource://gre/modules/Services.jsm");
-              Services.perms.remove(arguments[0], arguments[1]);
+              let uri = Services.io.newURI(arguments[0], null, null);
+              Services.perms.remove(uri, arguments[1]);
             """, script_args=[host, permission])
 
     def sanitize(self, data_type):

--- a/firefox_ui_tests/remote/security/test_safe_browsing_notification.py
+++ b/firefox_ui_tests/remote/security/test_safe_browsing_notification.py
@@ -51,7 +51,7 @@ class TestSafeBrowsingNotificationBar(FirefoxTestCase):
 
     def tearDown(self):
         try:
-            self.utils.remove_perms('www.itisatrap.org', 'safe-browsing')
+            self.utils.remove_perms('https://www.itisatrap.org', 'safe-browsing')
             self.browser.tabbar.close_all_tabs([self.browser.tabbar.tabs[0]])
         finally:
             FirefoxTestCase.tearDown(self)
@@ -98,7 +98,7 @@ class TestSafeBrowsingNotificationBar(FirefoxTestCase):
         self.assertEquals(self.marionette.get_url(), self.browser.get_final_url(unsafe_page))
 
         # Clean up here since the permission gets set in this function
-        self.utils.remove_perms('www.itisatrap.org', 'safe-browsing')
+        self.utils.remove_perms('https://www.itisatrap.org', 'safe-browsing')
 
     # Check the not a forgery or attack button in the notification bar
     def check_not_badware_button(self, button_property, report_page):

--- a/firefox_ui_tests/remote/security/test_safe_browsing_warning_pages.py
+++ b/firefox_ui_tests/remote/security/test_safe_browsing_warning_pages.py
@@ -37,7 +37,7 @@ class TestSafeBrowsingWarningPages(FirefoxTestCase):
 
     def tearDown(self):
         try:
-            self.utils.remove_perms('www.itisatrap.org', 'safe-browsing')
+            self.utils.remove_perms('https://www.itisatrap.org', 'safe-browsing')
             self.browser.tabbar.close_all_tabs([self.browser.tabbar.tabs[0]])
         finally:
             FirefoxTestCase.tearDown(self)
@@ -102,4 +102,4 @@ class TestSafeBrowsingWarningPages(FirefoxTestCase):
         self.assertEquals(self.marionette.get_url(), self.browser.get_final_url(unsafe_page))
 
         # Clean up by removing safe browsing permission for unsafe page
-        self.utils.remove_perms('www.itisatrap.org', 'safe-browsing')
+        self.utils.remove_perms('https://www.itisatrap.org', 'safe-browsing')


### PR DESCRIPTION
… for api change in nsIPermissionManager