### PR TITLE
Bug 1196006 - skip window tests that are timing out or failing

### DIFF
--- a/firefox_puppeteer/tests/test_about_window.py
+++ b/firefox_puppeteer/tests/test_about_window.py
@@ -4,9 +4,11 @@
 
 from marionette_driver import By
 
+from firefox_ui_harness.decorators import skip_under_xvfb
 from firefox_ui_harness import FirefoxTestCase
 
 
+@skip_under_xvfb
 class TestAboutWindow(FirefoxTestCase):
 
     def setUp(self):

--- a/firefox_puppeteer/tests/test_about_window.py
+++ b/firefox_puppeteer/tests/test_about_window.py
@@ -2,11 +2,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import unittest
+
 from marionette_driver import By
 
 from firefox_ui_harness import FirefoxTestCase
 
 
+@unittest.skip('Bug 1196006 - test_about_window.py and test_page_info_window.py time out...')
 class TestAboutWindow(FirefoxTestCase):
 
     def setUp(self):

--- a/firefox_puppeteer/tests/test_about_window.py
+++ b/firefox_puppeteer/tests/test_about_window.py
@@ -2,14 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import unittest
-
 from marionette_driver import By
 
 from firefox_ui_harness import FirefoxTestCase
 
 
-@unittest.skip('Bug 1196006 - test_about_window.py and test_page_info_window.py time out...')
 class TestAboutWindow(FirefoxTestCase):
 
     def setUp(self):

--- a/firefox_puppeteer/tests/test_page_info_window.py
+++ b/firefox_puppeteer/tests/test_page_info_window.py
@@ -3,9 +3,12 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from marionette_driver import By
+
+from firefox_ui_harness.decorators import skip_under_xvfb
 from firefox_ui_harness import FirefoxTestCase
 
 
+@skip_under_xvfb
 class TestPageInfoWindow(FirefoxTestCase):
 
     def tearDown(self):

--- a/firefox_puppeteer/tests/test_page_info_window.py
+++ b/firefox_puppeteer/tests/test_page_info_window.py
@@ -2,13 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import unittest
-
 from marionette_driver import By
 from firefox_ui_harness import FirefoxTestCase
 
 
-@unittest.skip('Bug 1196006 - test_about_window.py and test_page_info_window.py time out...')
 class TestPageInfoWindow(FirefoxTestCase):
 
     def tearDown(self):

--- a/firefox_puppeteer/tests/test_page_info_window.py
+++ b/firefox_puppeteer/tests/test_page_info_window.py
@@ -2,10 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import unittest
+
 from marionette_driver import By
 from firefox_ui_harness import FirefoxTestCase
 
 
+@unittest.skip('Bug 1196006 - test_about_window.py and test_page_info_window.py time out...')
 class TestPageInfoWindow(FirefoxTestCase):
 
     def tearDown(self):

--- a/firefox_puppeteer/tests/test_windows.py
+++ b/firefox_puppeteer/tests/test_windows.py
@@ -7,6 +7,7 @@ from marionette_driver.errors import NoSuchWindowException, TimeoutException
 
 import firefox_puppeteer.errors as errors
 
+from firefox_ui_harness.decorators import skip_under_xvfb
 from firefox_ui_harness import FirefoxTestCase
 from firefox_puppeteer.ui.windows import BaseWindow
 
@@ -92,6 +93,7 @@ class TestBaseWindow(FirefoxTestCase):
         self.assertRaises(KeyError,
                           win1.send_shortcut, 'l', acel=True)
 
+    @skip_under_xvfb
     def test_open_close(self):
         # force BaseWindow instance
         win1 = BaseWindow(lambda: self.marionette, self.browser.handle)
@@ -137,6 +139,7 @@ class TestBaseWindow(FirefoxTestCase):
                           win1.open_window, expected_window_class=BaseWindow)
         self.windows.close_all([win1])
 
+    @skip_under_xvfb
     def test_switch_to_and_focus(self):
         # force BaseWindow instance
         win1 = BaseWindow(lambda: self.marionette, self.browser.handle)
@@ -191,6 +194,7 @@ class TestBrowserWindow(FirefoxTestCase):
         self.assertIsNotNone(self.browser.navbar)
         self.assertIsNotNone(self.browser.tabbar)
 
+    @skip_under_xvfb
     def test_open_close(self):
         # open and close a new browser windows by menu
         win2 = self.browser.open_browser(trigger='menu')

--- a/firefox_puppeteer/tests/test_windows.py
+++ b/firefox_puppeteer/tests/test_windows.py
@@ -2,8 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import unittest
-
 from marionette_driver import By, Wait
 from marionette_driver.errors import NoSuchWindowException, TimeoutException
 
@@ -65,7 +63,6 @@ class TestWindows(FirefoxTestCase):
         self.assertEqual(len(self.windows.all), 1)
 
 
-@unittest.skip('Bug 1196006 - test_about_window.py and test_page_info_window.py time out...')
 class TestBaseWindow(FirefoxTestCase):
 
     def tearDown(self):
@@ -176,7 +173,6 @@ class TestBaseWindow(FirefoxTestCase):
         win1.switch_to()
 
 
-@unittest.skip('Bug 1196006 - test_about_window.py and test_page_info_window.py time out...')
 class TestBrowserWindow(FirefoxTestCase):
 
     def tearDown(self):

--- a/firefox_puppeteer/tests/test_windows.py
+++ b/firefox_puppeteer/tests/test_windows.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import unittest
+
 from marionette_driver import By, Wait
 from marionette_driver.errors import NoSuchWindowException, TimeoutException
 
@@ -63,6 +65,7 @@ class TestWindows(FirefoxTestCase):
         self.assertEqual(len(self.windows.all), 1)
 
 
+@unittest.skip('Bug 1196006 - test_about_window.py and test_page_info_window.py time out...')
 class TestBaseWindow(FirefoxTestCase):
 
     def tearDown(self):
@@ -173,6 +176,7 @@ class TestBaseWindow(FirefoxTestCase):
         win1.switch_to()
 
 
+@unittest.skip('Bug 1196006 - test_about_window.py and test_page_info_window.py time out...')
 class TestBrowserWindow(FirefoxTestCase):
 
     def tearDown(self):

--- a/firefox_ui_tests/functional/private_browsing/test_about_private_browsing.py
+++ b/firefox_ui_tests/functional/private_browsing/test_about_private_browsing.py
@@ -4,7 +4,7 @@
 
 from marionette_driver import By, Wait
 
-from firefox_ui_harness.decorators import skip_if_e10s
+from firefox_ui_harness.decorators import skip_if_e10s, skip_under_xvfb
 from firefox_ui_harness import FirefoxTestCase
 
 from firefox_puppeteer.ui.windows import BrowserWindow
@@ -21,6 +21,7 @@ class TestAboutPrivateBrowsing(FirefoxTestCase):
 
         self.pb_url = support_url + 'private-browsing'
 
+    @skip_under_xvfb
     @skip_if_e10s
     def testCheckAboutPrivateBrowsing(self):
         self.assertFalse(self.browser.is_private)

--- a/firefox_ui_tests/functional/private_browsing/test_about_private_browsing.py
+++ b/firefox_ui_tests/functional/private_browsing/test_about_private_browsing.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import unittest
+
 from marionette_driver import By, Wait
 
 from firefox_ui_harness.decorators import skip_if_e10s
@@ -10,6 +12,7 @@ from firefox_ui_harness import FirefoxTestCase
 from firefox_puppeteer.ui.windows import BrowserWindow
 
 
+@unittest.skip('Bug 1196006 - test_about_window.py and test_page_info_window.py time out...')
 class TestAboutPrivateBrowsing(FirefoxTestCase):
 
     def setUp(self):

--- a/firefox_ui_tests/functional/private_browsing/test_about_private_browsing.py
+++ b/firefox_ui_tests/functional/private_browsing/test_about_private_browsing.py
@@ -2,8 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import unittest
-
 from marionette_driver import By, Wait
 
 from firefox_ui_harness.decorators import skip_if_e10s
@@ -12,7 +10,6 @@ from firefox_ui_harness import FirefoxTestCase
 from firefox_puppeteer.ui.windows import BrowserWindow
 
 
-@unittest.skip('Bug 1196006 - test_about_window.py and test_page_info_window.py time out...')
 class TestAboutPrivateBrowsing(FirefoxTestCase):
 
     def setUp(self):


### PR DESCRIPTION
test_about_window.py has been timing out on Travis Linux worker, and when skipped, test_page_info_window, too, times out...