### PR TITLE
Bug 1196006 - Fix skips for tests that are timing out

### DIFF
--- a/firefox_puppeteer/tests/test_about_window.py
+++ b/firefox_puppeteer/tests/test_about_window.py
@@ -4,18 +4,11 @@
 
 from marionette_driver import By
 
-from firefox_ui_harness.decorators import skip_under_xvfb
 from firefox_ui_harness import FirefoxTestCase
+from firefox_ui_harness.decorators import skip_under_xvfb
 
 
-@skip_under_xvfb
 class TestAboutWindow(FirefoxTestCase):
-
-    def setUp(self):
-        FirefoxTestCase.setUp(self)
-
-        self.about_window = self.browser.open_about_window()
-        self.deck = self.about_window.deck
 
     def tearDown(self):
         try:
@@ -23,11 +16,17 @@ class TestAboutWindow(FirefoxTestCase):
         finally:
             FirefoxTestCase.tearDown(self)
 
+    @skip_under_xvfb
     def test_basic(self):
+        self.about_window = self.browser.open_about_window()
         self.assertEqual(self.about_window.window_type, 'Browser:About')
 
+    @skip_under_xvfb
     def test_elements(self):
         """Test correct retrieval of elements."""
+        self.about_window = self.browser.open_about_window()
+        self.deck = self.about_window.deck
+
         self.assertNotEqual(self.about_window.dtds, [])
 
         self.assertEqual(self.deck.element.get_attribute('localName'), 'deck')
@@ -61,8 +60,11 @@ class TestAboutWindow(FirefoxTestCase):
         # downloading panel
         self.assertEqual(self.deck.downloading.element.get_attribute('localName'), 'hbox')
 
+    @skip_under_xvfb
     def test_open_window(self):
         """Test various opening strategies."""
+        self.about_window = self.browser.open_about_window()
+
         def opener(win):
             menu = win.marionette.find_element(By.ID, 'aboutName')
             menu.click()
@@ -77,6 +79,9 @@ class TestAboutWindow(FirefoxTestCase):
             self.assertEquals(about_window, self.windows.current)
             about_window.close()
 
+    @skip_under_xvfb
     def test_patch_info(self):
+        self.about_window = self.browser.open_about_window()
+
         self.assertEqual(self.about_window.patch_info['download_duration'], None)
         self.assertIsNotNone(self.about_window.patch_info['channel'])

--- a/firefox_puppeteer/tests/test_page_info_window.py
+++ b/firefox_puppeteer/tests/test_page_info_window.py
@@ -4,11 +4,10 @@
 
 from marionette_driver import By
 
-from firefox_ui_harness.decorators import skip_under_xvfb
 from firefox_ui_harness import FirefoxTestCase
+from firefox_ui_harness.decorators import skip_under_xvfb
 
 
-@skip_under_xvfb
 class TestPageInfoWindow(FirefoxTestCase):
 
     def tearDown(self):
@@ -17,6 +16,7 @@ class TestPageInfoWindow(FirefoxTestCase):
         finally:
             FirefoxTestCase.tearDown(self)
 
+    @skip_under_xvfb
     def test_elements(self):
         """Test correct retrieval of elements."""
         page_info = self.browser.open_page_info_window()
@@ -51,6 +51,7 @@ class TestPageInfoWindow(FirefoxTestCase):
         self.assertEqual(panel.view_cookies.get_attribute('localName'), 'button')
         self.assertEqual(panel.view_passwords.get_attribute('localName'), 'button')
 
+    @skip_under_xvfb
     def test_select(self):
         """Test properties and methods for switching between panels."""
         page_info = self.browser.open_page_info_window()
@@ -61,6 +62,7 @@ class TestPageInfoWindow(FirefoxTestCase):
         self.assertEqual(deck.select(deck.security), deck.security)
         self.assertEqual(deck.selected_panel, deck.security)
 
+    @skip_under_xvfb
     def test_open_window(self):
         """Test various opening strategies."""
         def opener(win):
@@ -82,6 +84,7 @@ class TestPageInfoWindow(FirefoxTestCase):
             self.assertEquals(page_info, self.windows.current)
             page_info.close()
 
+    @skip_under_xvfb
     def test_close_window(self):
         """Test various closing strategies."""
         def closer(win):


### PR DESCRIPTION
Skips should generally be put on tests, not on classes. 

(Adding a skip to a class disables all its tests, for ALL test runs.)