### PR TITLE
Bug 1207284 - Make Travis CI specific settings for mozilla-release

### DIFF
--- a/.pep8.rc
+++ b/.pep8.rc
@@ -1,0 +1,3 @@
+[pep8]
+max-line-length = 99
+exclude = firefox_puppeteer/docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,55 @@
+sudo: false
+
+language: c
+
+os:
+    - osx
+    - linux
+
+compiler:
+    # we don't require a C compiler! if we don't specify one here, we get extra builds,
+    # for both gcc and clang
+    - gcc
+
+env:
+    # Test with our internal pypi mirror
+    - PIP_FIND_LINKS=http://pypi.pub.build.mozilla.org/pub
+      PIP_NO_INDEX=1
+      DISPLAY=$(if [[ $TRAVIS_OS_NAME = 'linux' ]]; then echo ':99'; fi)
+      MOZ_XVFB=$(if [[ $TRAVIS_OS_NAME = 'linux' ]]; then echo 1; fi)
+      PIP_STRICT_VERSIONS=--strict
+    # ... and with the official pypi website
+    - DISPLAY=$(if [[ $TRAVIS_OS_NAME = 'linux' ]]; then echo ':99'; fi)
+      MOZ_XVFB=$(if [[ $TRAVIS_OS_NAME = 'linux' ]]; then echo 1; fi)
+      PIP_STRICT_VERSIONS=
+
+before_install:
+    - if [ "$TRAVIS_OS_NAME" == "linux" ]; then /sbin/start-stop-daemon --start --quiet --make-pidfile --pidfile /tmp/custom_xvfb_99.pid --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x768x24 ; fi
+
+install:
+    # We need to either pin our marionette version or get every dependent package from
+    # tree to avoid bustage. Pinning marionette means we're more likely to work out of the
+    # the box for those working locally without a clone of m-c.
+    # - svn checkout https://github.com/mozilla/gecko-dev/trunk/testing/marionette/client
+    # - "cd client && python setup.py develop && cd .."
+
+    - python create_venv.py $PIP_STRICT_VERSIONS --with-optional-packages ~/.venv
+    - source ~/.venv/bin/activate
+
+before_script:
+    # Run pep8 on all except the checked out marionette-client folder
+    - pep8 --config ./.pep8.rc --exclude=client .
+
+    # Prepare the build and everything else
+    - ./.travis/before_script.sh
+
+script:
+    # Run in non-e10s mode
+    - firefox-ui-tests --installer *firefox-* --gecko-log -
+
+    # Run in e10s mode
+    - firefox-ui-tests --installer *firefox-* --gecko-log - --e10s
+
+notifications:
+    irc:
+        - "irc.mozilla.org#automation"

--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -ev
+
+mozdownload --type tinderbox --branch mozilla-esr38


### PR DESCRIPTION
We haven't run Travis on mozilla-esr38 yet. So we need the complete files.