### PR TITLE
Bug 1204093 Add a non-ascii locale *improved*

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,10 @@ compiler:
 
 env:
   global:
+    - MOZ_BRANCH='mozilla-central'
     - DISPLAY=$(if [[ $TRAVIS_OS_NAME = 'linux' ]]; then echo ':99'; fi)
     - MOZ_XVFB=$(if [[ $TRAVIS_OS_NAME = 'linux' ]]; then echo 1; fi)
-    - MOZ_BRANCH='mozilla-central'
+    - PIP_STRICT_VERSIONS=
   matrix:
     # Test with our internal pypi mirror / locale en-US
     - LOCALE='en-US'
@@ -25,11 +26,9 @@ env:
 
     # ... and with the official pypi website / locale en-US
     - LOCALE='en-US'
-      PIP_STRICT_VERSIONS=
 
     # ... and again with the official pypi website / locale ru
     - LOCALE='ru'
-      PIP_STRICT_VERSIONS=
 
 before_install:
     - if [ "$TRAVIS_OS_NAME" == "linux" ]; then /sbin/start-stop-daemon --start --quiet --make-pidfile --pidfile /tmp/custom_xvfb_99.pid --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x768x24 ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ env:
     - MOZ_BRANCH='mozilla-central'
     - DISPLAY=$(if [[ $TRAVIS_OS_NAME = 'linux' ]]; then echo ':99'; fi)
     - MOZ_XVFB=$(if [[ $TRAVIS_OS_NAME = 'linux' ]]; then echo 1; fi)
-    - PIP_STRICT_VERSIONS=
   matrix:
     # Test with our internal pypi mirror / locale en-US
     - LOCALE='en-US'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,24 +12,23 @@ compiler:
     - gcc
 
 env:
+  global:
+    - DISPLAY=$(if [[ $TRAVIS_OS_NAME = 'linux' ]]; then echo ':99'; fi)
+    - MOZ_XVFB=$(if [[ $TRAVIS_OS_NAME = 'linux' ]]; then echo 1; fi)
+    - MOZ_BRANCH='mozilla-central'
+  matrix:
     # Test with our internal pypi mirror / locale en-US
     - LOCALE='en-US'
       PIP_FIND_LINKS=http://pypi.pub.build.mozilla.org/pub
       PIP_NO_INDEX=1
-      DISPLAY=$(if [[ $TRAVIS_OS_NAME = 'linux' ]]; then echo ':99'; fi)
-      MOZ_XVFB=$(if [[ $TRAVIS_OS_NAME = 'linux' ]]; then echo 1; fi)
       PIP_STRICT_VERSIONS=--strict
 
     # ... and with the official pypi website / locale en-US
     - LOCALE='en-US'
-      DISPLAY=$(if [[ $TRAVIS_OS_NAME = 'linux' ]]; then echo ':99'; fi)
-      MOZ_XVFB=$(if [[ $TRAVIS_OS_NAME = 'linux' ]]; then echo 1; fi)
       PIP_STRICT_VERSIONS=
 
     # ... and again with the official pypi website / locale ru
     - LOCALE='ru'
-      DISPLAY=$(if [[ $TRAVIS_OS_NAME = 'linux' ]]; then echo ':99'; fi)
-      MOZ_XVFB=$(if [[ $TRAVIS_OS_NAME = 'linux' ]]; then echo 1; fi)
       PIP_STRICT_VERSIONS=
 
 before_install:
@@ -50,7 +49,7 @@ before_script:
     - pep8 --config ./.pep8.rc --exclude=client .
 
     # Prepare the build and everything else
-    - mozdownload --type daily --branch $TRAVIS_BRANCH --locale $LOCALE
+    - mozdownload --type daily --branch $MOZ_BRANCH --locale $LOCALE
 
 script:
     # Run in non-e10s mode

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ before_script:
     - pep8 --config ./.pep8.rc --exclude=client .
 
     # Prepare the build and everything else
-    - ./.travis/before_script.sh
+    - mozdownload --type daily --branch $TRAVIS_BRANCH --locale $LOCALE
 
 script:
     # Run in non-e10s mode

--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-set -ev
-
-if [[ $LOCALE = 'en-US' ]]
-then
-    mozdownload --type daily --branch mozilla-central
-else
-    mozdownload --type daily --branch mozilla-central --locale ru
-fi


### PR DESCRIPTION
This version of the PR should be suitable for both mozilla-central and for mozilla-aurora. (For the beta and release branches, it looks like mozdownload should use --type release, rather than --type daily.)

This PR removes .travis/before_script.sh.
