### PR TITLE
Bug 1223543 - Make use of new MarionetteHarness; r=whimboo

### DIFF
--- a/firefox_ui_harness/arguments/base.py
+++ b/firefox_ui_harness/arguments/base.py
@@ -14,10 +14,6 @@ class FirefoxUIBaseArguments(object):
         [['--installer'], {
             'help': 'Installer of a Gecko application to use for running the tests'
         }],
-        [['--workspace'], {
-            'dest': 'workspace_path',
-            'help': 'Path to use for all temporary data. Defaults to TEMP.'
-        }]
     ]
 
     def parse_args_handler(self, args):

--- a/firefox_ui_harness/cli_update.py
+++ b/firefox_ui_harness/cli_update.py
@@ -4,12 +4,14 @@
 
 from firefox_ui_harness.arguments import UpdateArguments
 from firefox_ui_harness.runners import UpdateTestRunner
-from firefox_ui_harness.runtests import cli
+from firefox_ui_harness.runtests import FirefoxUIHarness
+from marionette.runtests import cli
 
 
 def cli_update():
-    cli(runner_class=UpdateTestRunner, parser_class=UpdateArguments)
-
+    cli(runner_class=UpdateTestRunner,
+        parser_class=UpdateArguments,
+        harness_class=FirefoxUIHarness)
 
 if __name__ == '__main__':
     cli_update()

--- a/firefox_ui_harness/runners/base.py
+++ b/firefox_ui_harness/runners/base.py
@@ -11,63 +11,13 @@ import firefox_ui_tests
 from firefox_puppeteer.testcases import FirefoxTestCase
 
 
-DEFAULT_PREFS = {
-    'app.update.auto': False,
-    'app.update.enabled': False,
-    'browser.dom.window.dump.enabled': True,
-    # Bug 1145668 - Has to be reverted to about:blank once Marionette
-    # can correctly handle error pages
-    'browser.newtab.url': 'about:newtab',
-    'browser.newtabpage.enabled': False,
-    'browser.reader.detectedFirstArticle': True,
-    'browser.safebrowsing.enabled': False,
-    'browser.safebrowsing.malware.enabled': False,
-    'browser.search.update': False,
-    'browser.sessionstore.resume_from_crash': False,
-    'browser.shell.checkDefaultBrowser': False,
-    'browser.startup.page': 0,
-    'browser.tabs.animate': False,
-    'browser.tabs.warnOnClose': False,
-    'browser.tabs.warnOnOpen': False,
-    'browser.uitour.enabled': False,
-    'browser.warnOnQuit': False,
-    'dom.ipc.reportProcessHangs': False,
-    'dom.report_all_js_exceptions': True,
-    'extensions.enabledScopes': 5,
-    'extensions.autoDisableScopes': 10,
-    'extensions.getAddons.cache.enabled': False,
-    'extensions.installDistroAddons': False,
-    'extensions.logging.enabled': True,
-    'extensions.showMismatchUI': False,
-    'extensions.update.enabled': False,
-    'extensions.update.notifyUser': False,
-    'focusmanager.testmode': True,
-    'geo.provider.testing': True,
-    'javascript.options.showInConsole': True,
-    'marionette.logging': False,
-    'security.notification_enable_delay': 0,
-    'signon.rememberSignons': False,
-    'startup.homepage_welcome_url': 'about:blank',
-    'toolkit.startup.max_resumed_crashes': -1,
-    'toolkit.telemetry.enabled': False,
-}
-
-
 class FirefoxUITestRunner(BaseMarionetteTestRunner):
     def __init__(self, **kwargs):
         BaseMarionetteTestRunner.__init__(self, **kwargs)
-
+        # select the appropriate GeckoInstance
+        self.app = 'fxdesktop'
         if not self.server_root:
             self.server_root = firefox_ui_tests.resources
-
-        # Bug 1146847: This needs a refactoring given that our default
-        # preferences are not coming from the command line
-        self.prefs.update(DEFAULT_PREFS)
-
-        if not kwargs.get('e10s'):
-            self.prefs.update({'browser.tabs.remote.autostart': False})
-
-        self.workspace = kwargs.get('workspace')
 
         self.test_handlers = [FirefoxTestCase]
 
@@ -78,11 +28,3 @@ class FirefoxUITestRunner(BaseMarionetteTestRunner):
             return binary[:end_index]
         else:
             return os.path.dirname(binary)
-
-    def run_tests(self, tests):
-        # Ensure Marionette is always reset before starting tests
-        # This might need support in Marionette base
-        self.marionette = None
-        self.tests = []
-
-        BaseMarionetteTestRunner.run_tests(self, tests)

--- a/firefox_ui_harness/runners/update.py
+++ b/firefox_ui_harness/runners/update.py
@@ -42,7 +42,7 @@ class UpdateTestRunner(FirefoxUITestRunner):
 
     def duplicate_application(self, application_folder):
         """Creates a copy of the specified binary."""
-        target_folder = os.path.join(self.workspace, 'binary.backup')
+        target_folder = os.path.join(self.workspace_path, 'binary.backup')
 
         self.logger.info('Creating a copy of the application at "%s".' % target_folder)
         mozfile.remove(target_folder)

--- a/firefox_ui_harness/runners/update.py
+++ b/firefox_ui_harness/runners/update.py
@@ -38,11 +38,17 @@ class UpdateTestRunner(FirefoxUITestRunner):
         self.run_direct_update = not kwargs.pop('update_fallback_only', False)
         self.run_fallback_update = not kwargs.pop('update_direct_only', False)
 
+        # Used in case no workspace is set
+        self.installer_workspace = kwargs.pop('installer_workspace',
+                                              self.workspace_path)
+
         self.test_handlers = [UpdateTestCase]
 
     def duplicate_application(self, application_folder):
         """Creates a copy of the specified binary."""
-        target_folder = os.path.join(self.workspace_path, 'binary.backup')
+
+        target_folder = os.path.join(self.workspace or self.installer_workspace,
+                                     'binary.backup')
 
         self.logger.info('Creating a copy of the application at "%s".' % target_folder)
         mozfile.remove(target_folder)

--- a/firefox_ui_harness/runners/update.py
+++ b/firefox_ui_harness/runners/update.py
@@ -47,8 +47,7 @@ class UpdateTestRunner(FirefoxUITestRunner):
     def duplicate_application(self, application_folder):
         """Creates a copy of the specified binary."""
 
-        target_folder = os.path.join(self.workspace or self.installer_workspace,
-                                     'binary.backup')
+        target_folder = os.path.join(self.installer_workspace, 'binary.backup')
 
         self.logger.info('Creating a copy of the application at "%s".' % target_folder)
         mozfile.remove(target_folder)

--- a/firefox_ui_harness/runtests.py
+++ b/firefox_ui_harness/runtests.py
@@ -7,71 +7,53 @@ import sys
 import tempfile
 
 import mozinstall
-
-from mozlog import structured
+from marionette.runtests import MarionetteHarness, cli as mn_cli
 
 from firefox_ui_harness.arguments import FirefoxUIArguments
 from firefox_ui_harness.runners import FirefoxUITestRunner
 
 
-def startTestRunner(runner_class, options, tests):
-    install_folder = None
+class FirefoxUIHarness(MarionetteHarness):
+    def __init__(self,
+                 runner_class=FirefoxUITestRunner,
+                 parser_class=FirefoxUIArguments):
+        MarionetteHarness.__init__(self, runner_class, parser_class)
+        self.install_folder = None
 
-    try:
-        # Prepare the workspace path so that all temporary data can be stored inside it.
-        if options.workspace_path:
-            path = os.path.expanduser(options.workspace_path)
-            options.workspace = os.path.abspath(path)
-
-            if not os.path.exists(options.workspace):
-                os.makedirs(options.workspace)
-        else:
-            options.workspace = tempfile.mkdtemp('.{}'.format(os.path.basename(sys.argv[0])))
-
-        options.logger.info('Using workspace for temporary data: "{}"'.format(options.workspace))
-
+    def process_args(self):
+        # TODO move installer to mozharness script.
         # If the specified binary is an installer it needs to be installed
-        if options.installer:
-            installer = os.path.realpath(options.installer)
+        if self.args.installer:
+            installer = os.path.realpath(self.args.installer)
 
-            dest_folder = os.path.join(options.workspace, 'binary')
-            options.logger.info('Installing application "%s" to "%s"' % (installer,
-                                                                         dest_folder))
-            install_folder = mozinstall.install(installer, dest_folder)
-            options.binary = mozinstall.get_binary(install_folder, 'firefox')
+            dest_folder = os.path.abspath(os.path.expanduser(
+                os.path.join(self.args.workspace or '', 'binary')
+            ))
+            self.args.logger.info(
+                'Installing application "%s" to "%s"' % (installer, dest_folder)
+            )
+            self.install_folder = mozinstall.install(installer, dest_folder)
+            self.args.binary = mozinstall.get_binary(self.install_folder,
+                                                     'firefox')
 
-        runner = runner_class(**vars(options))
-        runner.run_tests(tests)
+    def parse_args(self, *args, **kwargs):
+        return MarionetteHarness.parse_args(self, {'mach': sys.stdout})
 
-    finally:
-        # Ensure to uninstall the binary if it has been installed before
-        if install_folder and os.path.exists(install_folder):
-            options.logger.info('Uninstalling application at "%s"' % install_folder)
-            mozinstall.uninstall(install_folder)
+    def run(self):
+        try:
+            return MarionetteHarness.run(self)
+        finally:
+            # Ensure to uninstall the binary if it has been installed before
+            if self.install_folder and os.path.exists(self.install_folder):
+                self.args.logger.info('Uninstalling application at '
+                                      '"%s"' % self.install_folder)
+                mozinstall.uninstall(self.install_folder)
 
-    return runner
 
-
-def cli(runner_class=FirefoxUITestRunner, parser_class=FirefoxUIArguments):
-    parser = parser_class(usage='%(prog)s [options] test_file_or_dir <test_file_or_dir> ...')
-    structured.commandline.add_logging_group(parser)
-    args = parser.parse_args()
-    parser.verify_usage(args)
-
-    logger = structured.commandline.setup_logging(
-        args.logger_name, args, {'mach': sys.stdout})
-    args.logger = logger
-
-    try:
-        runner = startTestRunner(runner_class, args, args.tests)
-        if runner.failed > 0:
-            sys.exit(10)
-
-    except Exception:
-        logger.error('Failure during execution of the update test.',
-                     exc_info=True)
-        sys.exit(1)
-
+def cli():
+    mn_cli(runner_class=FirefoxUITestRunner,
+           parser_class=FirefoxUIArguments,
+           harness_class=FirefoxUIHarness)
 
 if __name__ == '__main__':
-    sys.exit(cli())
+    cli()

--- a/firefox_ui_harness/runtests.py
+++ b/firefox_ui_harness/runtests.py
@@ -26,9 +26,13 @@ class FirefoxUIHarness(MarionetteHarness):
         if self.args.installer:
             installer = os.path.realpath(self.args.installer)
 
-            dest_folder = os.path.abspath(os.path.expanduser(
-                os.path.join(self.args.workspace or '', 'binary')
-            ))
+            if not self.args.workspace:
+                self.args.installer_workspace = tempfile.mkdtemp(
+                    '.{}'.format(os.path.basename(sys.argv[0]))
+                )
+            else:
+                self.args.installer_workspace = self.args.workspace
+            dest_folder = os.path.join(self.args.installer_workspace, 'binary')
             self.args.logger.info(
                 'Installing application "%s" to "%s"' % (installer, dest_folder)
             )

--- a/firefox_ui_harness/runtests.py
+++ b/firefox_ui_harness/runtests.py
@@ -6,6 +6,7 @@ import os
 import sys
 import tempfile
 
+import mozfile
 import mozinstall
 from marionette.runtests import MarionetteHarness, cli as mn_cli
 
@@ -52,6 +53,15 @@ class FirefoxUIHarness(MarionetteHarness):
                 self.args.logger.info('Uninstalling application at '
                                       '"%s"' % self.install_folder)
                 mozinstall.uninstall(self.install_folder)
+            if not self.args.workspace:
+                self.args.logger.info(
+                    'Removing temporary installer workspace '
+                    'at "%s"' % self.args.installer_workspace
+                )
+                try:
+                    mozfile.remove(self.args.installer_workspace)
+                except IOError as e:
+                    self.logger.error('Cannot remove "%s"' % str(e))
 
 
 def cli():

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,11 @@
 
 from setuptools import setup, find_packages
 
-PACKAGE_VERSION = '0.2'
+PACKAGE_VERSION = '0.3'
 
 deps = [
-    'marionette-client == 1.1.0',
-    'marionette-driver == 1.1.0',
+    'marionette-client == 2.0.0',
+    'marionette-driver == 1.1.1',
     'mozfile == 1.2',
     'mozinfo == 0.8',
     'mozinstall == 1.12',


### PR DESCRIPTION
This involves bumping marionette versions to
marionette-client 2.0.0 and marionette-driver 1.1.1

Tested locally:
- `firefox-ui-tests --binary $FF_NIGHTLY_PATH --workspace blargh firefox_ui_tests/functional/locationbar/test_favicon_in_autocomplete.py`
- `firefox-ui-update --installer "temp/Firefox 41.0.dmg" --gecko-log logs/gecko.log --address localhost:2828 --workspace build`
  - When the test completes, ./build contains a 'binary' dir and two temporary
    Firefox profiles.
