### PR TITLE
Bug 1136902 - Added test file and method for utils sanitize method. r…

### DIFF
--- a/firefox_puppeteer/api/places.py
+++ b/firefox_puppeteer/api/places.py
@@ -6,7 +6,7 @@ from collections import namedtuple
 
 from marionette_driver.errors import MarionetteException, TimeoutException
 
-from ..base import BaseLib
+from firefox_puppeteer.base import BaseLib
 
 
 class Places(BaseLib):
@@ -104,6 +104,25 @@ class Places(BaseLib):
             raise errors.MarionetteException("Restore Default Bookmarks failed")
 
     # Browser history related helpers #
+
+    def get_all_urls_in_history(self):
+        return self.marionette.execute_script("""
+          let hs = Cc["@mozilla.org/browser/nav-history-service;1"]
+                   .getService(Ci.nsINavHistoryService);
+          let urls = [];
+
+          let options = hs.getNewQueryOptions();
+          options.resultType = options.RESULTS_AS_URI;
+
+          let root = hs.executeQuery(hs.getNewQuery(), options).root
+          root.containerOpen = true;
+          for (let i = 0; i < root.childCount; i++) {
+            urls.push(root.getChild(i).uri)
+          }
+          root.containerOpen = false;
+
+          return urls;
+        """)
 
     def remove_all_history(self):
         """Removes all history items."""

--- a/firefox_puppeteer/tests/test_utils.py
+++ b/firefox_puppeteer/tests/test_utils.py
@@ -1,0 +1,45 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from firefox_ui_harness import FirefoxTestCase
+
+
+class TestSanitize(FirefoxTestCase):
+
+    def setUp(self):
+        FirefoxTestCase.setUp(self)
+
+        # Clear all previous history and cookies.
+        self.places.remove_all_history()
+        self.marionette.delete_all_cookies()
+
+        self.urls = [
+            'layout/mozilla_projects.html',
+            'layout/mozilla.html',
+            'layout/mozilla_mission.html',
+            'cookies/cookie_single.html'
+        ]
+        self.urls = [self.marionette.absolute_url(url) for url in self.urls]
+
+        # Open the test urls, including the single cookie setting page.
+        def load_urls():
+            with self.marionette.using_context('content'):
+                for url in self.urls:
+                    self.marionette.navigate(url)
+        self.places.wait_for_visited(self.urls, load_urls)
+
+    def tearDown(self):
+        FirefoxTestCase.tearDown(self)
+
+    def test_sanitize_history(self):
+        """ Clears history. """
+        self.assertEqual(self.places.get_all_urls_in_history(), self.urls)
+        self.utils.sanitize(data_type={"history": True})
+        self.assertEqual(self.places.get_all_urls_in_history(), [])
+
+    def test_sanitize_cookies(self):
+        """ Clears cookies. """
+        self.assertIsNotNone(self.marionette.get_cookie('litmus_1'))
+        self.utils.sanitize(data_type={"cookies": True})
+        self.assertIsNone(self.marionette.get_cookie('litmus_1'))

--- a/firefox_ui_tests/resources/cookies/cookie_single.html
+++ b/firefox_ui_tests/resources/cookies/cookie_single.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+<script type="text/javascript">
+  function setCookie()
+  {
+    var date = new Date();
+    date.setDate(new Date().getDate() + 36);
+    document.cookie = "litmus_1=true;expires=" + date.toGMTString();
+  }
+</script>
+</head>
+
+<body onload="setCookie()">
+</body>
+</html>


### PR DESCRIPTION
…=sandeep@sandeepmurthy.is

Bug 1136902 - Fixed PEP8 linter errors in last commit. r=sandeep@sandeepmurthy.is

Bug 1136902 - Separate sanitize test into separate resource type sanitize tests

Bug 1136902 - Move cookies file into cookies subfolder

Bug 1136902 - Remove old cookies file

Bug 1136902 - Remove trailing whitespace

Bug 1136902 - requested changes from last review

Bug 1136902 - removed line break

Bug 1136902 - Fixed test failures, plus requested changes from last review
